### PR TITLE
fix: #36288: useAuthenticate returns false if authprovider is initially authenticated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ node_modules
 dist
 lib
 esm
-
+coverage
 

--- a/packages/echo-core/src/hooks/useAuthenticate.ts
+++ b/packages/echo-core/src/hooks/useAuthenticate.ts
@@ -9,6 +9,8 @@ const useAuthenticate = (authProvider: AuthenticationProvider, logRequest?: (...
             authProvider.handleLogin(logRequest).then(() => {
                 setIsAuthenticated(authProvider.isAuthenticated);
             });
+        } else {
+            setIsAuthenticated(authProvider.isAuthenticated);
         }
     }, [authProvider, logRequest]);
 


### PR DESCRIPTION
## Prerequisites

Please make sure you can check the following boxes:

-   [x] My code follows the code style of this project
-   [x] All new and existing tests passed - no tests written for this initially 
-   [x] Fix any eslint/prettier warnings/errors: npm run lint
-   [x] Remove unnecessary console.log (use logInfo logWarn if it's needed)
-   [x] Are variable and function names properly describing what it does?

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

-   [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id) 
          - found in relation to #36288: Make a pilot for including Ayelix 360 pictures in EchoInfield 
-   [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] I have updated the documentation accordingly
-   [ ] I have added tests to cover my changes
         - have other things to do that is more pressing at the moment. Also no initial tests on this hook

### Description

useAuthenticate hooken tar ikke høyde for at authprovideren kan ha isAuthenticated true on intital render. 
Oppdaget det da jeg testet ayelix module, hvis jeg først går til ayelix modulen, så til P&ID og så tilbake til ayelix så har auth provideren isAuthenticate = true, men slik koden er lagt opp så vil den allikevel returnere false.

### Bug fix: useAuthenticate returns false if authprovider is initially authenticated


