### PR TITLE
fix: instanceOf BaseError and child classes now works

### DIFF
--- a/packages/echo-base/package.json
+++ b/packages/echo-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-base",
-    "version": "0.2.94",
+    "version": "0.2.95",
     "module": "esm/index.js",
     "main": "lib/index.js",
     "typings": "lib/index.d.ts",

--- a/packages/echo-base/src/errors/BaseError.ts
+++ b/packages/echo-base/src/errors/BaseError.ts
@@ -14,6 +14,13 @@ export class BaseError extends Error {
 
     constructor({ message, exception }: BaseErrorArgs) {
         super(message);
+        /**
+         * Object.setPrototypeOf(this, new.target.prototype);: to fix instance of:
+         * https://stackoverflow.com/questions/55065742/implementing-instanceof-checks-for-custom-typescript-error-instances
+         * https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+         */
+
+        Object.setPrototypeOf(this, new.target.prototype);
         this.properties = exception ? { ...exception } : {};
         this.name = this.constructor.name;
         !message && (this.message = this.name);

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.2.94",
+    "version": "0.2.95",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
insatanceOf was not working, fixed by
https://stackoverflow.com/questions/55065742/implementing-instanceof-checks-for-custom-typescript-error-instances