### PR TITLE
feat: #49136 In goal of moving ayelix dependencies: added errorHandler registration

### DIFF
--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.3.19",
+    "version": "0.3.20",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.3.19",
+            "version": "0.3.20",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "2.8.0",

--- a/packages/echo-core/src/EchoCore.ts
+++ b/packages/echo-core/src/EchoCore.ts
@@ -9,6 +9,7 @@ import { useUserPhoto } from './hooks/useUserPhoto';
 import { useUserProfile } from './hooks/useUserProfile';
 import { EchoAuthProvider } from './services/authentication/echoProvider';
 import { echoClient } from './services/echoClient/echoClient';
+import { errorHandler } from './services/errorHandler/errorHandler';
 import * as moduleState from './state';
 import { useAppModuleState } from './state/useAppModuleState';
 import { ECHO_CORE_MAIN, ECHO_CORE_SEARCH } from './types';
@@ -27,6 +28,8 @@ export const EchoCore = {
     // Exposing all core Hooks
     hooks,
     moduleState: { ...moduleState, ...moduleActions },
+    handleErrors: errorHandler.handleErrors,
+    setErrorHandler: errorHandler.setErrorHandler,
     error,
     keys: {
         ECHO_CORE_MAIN: ECHO_CORE_MAIN,

--- a/packages/echo-core/src/__tests__/services/authProvider.test.ts
+++ b/packages/echo-core/src/__tests__/services/authProvider.test.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
 const globalConsoleMethod = global.console;
 beforeAll(() => {
     // removes console log in test run
-    global.console = ({ log: jest.fn(), error: jest.fn() } as unknown) as Console;
+    global.console = { log: jest.fn(), error: jest.fn() } as unknown as Console;
 });
 
 afterAll(() => {

--- a/packages/echo-core/src/__tests__/services/errorHandler.test.ts
+++ b/packages/echo-core/src/__tests__/services/errorHandler.test.ts
@@ -1,0 +1,23 @@
+import { errorHandler } from '../../../src/services/errorHandler/errorHandler';
+
+describe('errorHandler', () => {
+    describe('setErrorHandler()', () => {
+        it('should set an errorHandler function', () => {
+            // given
+            const testErrorHandlerFunc = jest.fn();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const params: any = {
+                error: new Error('custom error'),
+                analyticsModule: undefined
+            };
+
+            // when
+            errorHandler.setErrorHandler(testErrorHandlerFunc);
+            errorHandler.handleErrors(params.error, params.analyticsModule);
+
+            // then
+            expect(testErrorHandlerFunc).toHaveBeenCalledTimes(1);
+            expect(testErrorHandlerFunc).toHaveBeenCalledWith(params.error, params.analyticsModule);
+        });
+    });
+});

--- a/packages/echo-core/src/__tests__/services/graphUtils.test.ts
+++ b/packages/echo-core/src/__tests__/services/graphUtils.test.ts
@@ -1,4 +1,5 @@
-import { AccountInfo, AuthenticationResult } from '@azure/msal-browser';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { AuthenticationResult } from '@azure/msal-browser';
 import { User } from '@microsoft/microsoft-graph-types';
 import { EchoAuthProvider } from '../../services/authentication/echoProvider';
 import { graphGetProfile, graphGetProfilePicture } from '../../services/graph/graphUtils';
@@ -30,7 +31,7 @@ const globalConsoleMethod = global.console;
 const globalFetchMethod = window.fetch;
 beforeAll(() => {
     // removes console log in test run
-    global.console = ({ log: jest.fn(), error: jest.fn() } as unknown) as Console;
+    global.console = { log: jest.fn(), error: jest.fn() } as any;
 });
 
 afterAll(() => {
@@ -50,9 +51,9 @@ describe('graphGetProfile', () => {
         const mockFetch = jest.fn().mockImplementation(() => mockSuccessResponse);
         window.fetch = mockFetch;
         const accessToken = 'accessToken';
-        mockedEchoAuthProvider.userProperties.account = ({
+        mockedEchoAuthProvider.userProperties.account = {
             account: { username: 'test@test.no' }
-        } as unknown) as AccountInfo;
+        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue({
             accessToken
@@ -68,9 +69,9 @@ describe('graphGetProfile', () => {
         const mockFetch = jest.fn().mockImplementation(() => mockFailedResponse);
         window.fetch = mockFetch;
         const accessToken = 'accessToken';
-        mockedEchoAuthProvider.userProperties.account = ({
+        mockedEchoAuthProvider.userProperties.account = {
             account: { username: 'test@test.no' }
-        } as unknown) as AccountInfo;
+        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue({
             accessToken
@@ -84,9 +85,9 @@ describe('graphGetProfile', () => {
     it('should return undefined because token fetch failed', async () => {
         const mockFetch = jest.fn();
         window.fetch = mockFetch;
-        mockedEchoAuthProvider.userProperties.account = ({
+        mockedEchoAuthProvider.userProperties.account = {
             account: { username: 'test@test.no' }
-        } as unknown) as AccountInfo;
+        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue(null);
 
@@ -123,9 +124,9 @@ describe('graphGetProfilePicture', () => {
         window.URL.createObjectURL = mockCreateObjectURL;
 
         const accessToken = 'accessToken';
-        mockedEchoAuthProvider.userProperties.account = ({
+        mockedEchoAuthProvider.userProperties.account = {
             account: { username: 'test@test.no' }
-        } as unknown) as AccountInfo;
+        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue({
             accessToken
@@ -142,9 +143,9 @@ describe('graphGetProfilePicture', () => {
         window.fetch = mockFetch;
 
         const accessToken = 'accessToken';
-        mockedEchoAuthProvider.userProperties.account = ({
+        mockedEchoAuthProvider.userProperties.account = {
             account: { username: 'test@test.no' }
-        } as unknown) as AccountInfo;
+        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue({
             accessToken
@@ -161,9 +162,9 @@ describe('graphGetProfilePicture', () => {
         window.fetch = mockFetch;
 
         const accessToken = 'accessToken';
-        mockedEchoAuthProvider.userProperties.account = ({
+        mockedEchoAuthProvider.userProperties.account = {
             account: { username: 'test@test.no' }
-        } as unknown) as AccountInfo;
+        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue({
             accessToken
@@ -178,9 +179,9 @@ describe('graphGetProfilePicture', () => {
         const mockFetch = jest.fn();
         window.fetch = mockFetch;
 
-        mockedEchoAuthProvider.userProperties.account = ({
+        mockedEchoAuthProvider.userProperties.account = {
             account: { username: 'test@test.no' }
-        } as unknown) as AccountInfo;
+        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue(null);
 

--- a/packages/echo-core/src/__tests__/services/graphUtils.test.ts
+++ b/packages/echo-core/src/__tests__/services/graphUtils.test.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { AuthenticationResult } from '@azure/msal-browser';
+import { AccountInfo, AuthenticationResult } from '@azure/msal-browser';
 import { User } from '@microsoft/microsoft-graph-types';
 import { EchoAuthProvider } from '../../services/authentication/echoProvider';
 import { graphGetProfile, graphGetProfilePicture } from '../../services/graph/graphUtils';
@@ -25,13 +24,20 @@ const mockedEchoAuthProvider = EchoAuthProvider as jest.Mocked<typeof EchoAuthPr
 beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+
+    const accountMock = {
+        account: { username: 'test@test.no' }
+    } as unknown;
+
+    mockedEchoAuthProvider.userProperties.account = accountMock as AccountInfo;
 });
 
 const globalConsoleMethod = global.console;
 const globalFetchMethod = window.fetch;
 beforeAll(() => {
-    // removes console log in test run
-    global.console = { log: jest.fn(), error: jest.fn() } as any;
+    // overrides console log with a mock in test run
+    const mockConsole = { log: jest.fn(), error: jest.fn() } as unknown;
+    global.console = mockConsole as Console;
 });
 
 afterAll(() => {
@@ -51,9 +57,6 @@ describe('graphGetProfile', () => {
         const mockFetch = jest.fn().mockImplementation(() => mockSuccessResponse);
         window.fetch = mockFetch;
         const accessToken = 'accessToken';
-        mockedEchoAuthProvider.userProperties.account = {
-            account: { username: 'test@test.no' }
-        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue({
             accessToken
@@ -69,9 +72,6 @@ describe('graphGetProfile', () => {
         const mockFetch = jest.fn().mockImplementation(() => mockFailedResponse);
         window.fetch = mockFetch;
         const accessToken = 'accessToken';
-        mockedEchoAuthProvider.userProperties.account = {
-            account: { username: 'test@test.no' }
-        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue({
             accessToken
@@ -85,9 +85,6 @@ describe('graphGetProfile', () => {
     it('should return undefined because token fetch failed', async () => {
         const mockFetch = jest.fn();
         window.fetch = mockFetch;
-        mockedEchoAuthProvider.userProperties.account = {
-            account: { username: 'test@test.no' }
-        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue(null);
 
@@ -124,9 +121,6 @@ describe('graphGetProfilePicture', () => {
         window.URL.createObjectURL = mockCreateObjectURL;
 
         const accessToken = 'accessToken';
-        mockedEchoAuthProvider.userProperties.account = {
-            account: { username: 'test@test.no' }
-        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue({
             accessToken
@@ -143,9 +137,6 @@ describe('graphGetProfilePicture', () => {
         window.fetch = mockFetch;
 
         const accessToken = 'accessToken';
-        mockedEchoAuthProvider.userProperties.account = {
-            account: { username: 'test@test.no' }
-        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue({
             accessToken
@@ -162,9 +153,6 @@ describe('graphGetProfilePicture', () => {
         window.fetch = mockFetch;
 
         const accessToken = 'accessToken';
-        mockedEchoAuthProvider.userProperties.account = {
-            account: { username: 'test@test.no' }
-        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue({
             accessToken
@@ -178,10 +166,6 @@ describe('graphGetProfilePicture', () => {
     it('should return undefined because token fetch failed', async () => {
         const mockFetch = jest.fn();
         window.fetch = mockFetch;
-
-        mockedEchoAuthProvider.userProperties.account = {
-            account: { username: 'test@test.no' }
-        } as any;
 
         mockedEchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate.mockResolvedValue(null);
 

--- a/packages/echo-core/src/services/errorHandler/errorHandler.ts
+++ b/packages/echo-core/src/services/errorHandler/errorHandler.ts
@@ -1,0 +1,47 @@
+import { BaseError } from '@equinor/echo-base';
+import { AnalyticsModule } from '../../services/analytics/analyticsModule';
+
+type ErrorHandlerFunction = (exception: Error | BaseError | unknown, analyticsModule: AnalyticsModule) => void;
+interface ErrorHandler {
+    setErrorHandler: (handler: ErrorHandlerFunction) => void;
+    handleErrors: ErrorHandlerFunction;
+}
+
+// TODO: Remove when handleErrors is properly moved (and possibly reworked) to Core from EchoPedia
+export const errorHandler = ((): ErrorHandler => {
+    let errorHandlerFunction: ErrorHandlerFunction | undefined;
+
+    return {
+        /**
+         * Should be only used by EchopediaWeb, when bootstrapping Echo app.
+         * Use this method the set the errorHandler from Echopedia to EchoCore, so it's available for others to use.
+         * @param newErrorHandler {function} the new error handler to be set on Echo app initialization
+         */
+        setErrorHandler(newErrorHandler: ErrorHandlerFunction): void {
+            if (!errorHandlerFunction) {
+                errorHandlerFunction = newErrorHandler;
+            } else {
+                console.error(
+                    '[EchoCore.errorHandler.setErrorHandler] Can not set errorHandler: an errorHandler is already set.'
+                );
+            }
+        },
+        /**
+         * Calls a pre-set errorHandler. It should be set by EchopediaWeb.
+         * Handles the error if BaseError.hasBeenLogged is false, by:
+         * Logging the error, and also handles forbidden access.
+         * Argument unknown is allowed to make it compatible with try / catch
+         * @param exception {Error | BaseError | unknown} the error that caused the exception
+         * @param analyticsModule {AnalyticsModule} the given Echo App's analyticsModule
+         */
+        handleErrors(exception: Error | BaseError | unknown, analyticsModule: AnalyticsModule): void {
+            if (errorHandlerFunction) {
+                errorHandlerFunction(exception, analyticsModule);
+            } else {
+                console.error(
+                    '[EchoCore.errorHandler.handleErrors]: There is no errorHandler to call. Use EchoCore.setErrorHandler to set one.'
+                );
+            }
+        }
+    };
+})();

--- a/packages/echo-core/src/services/errorHandler/errorHandler.ts
+++ b/packages/echo-core/src/services/errorHandler/errorHandler.ts
@@ -7,7 +7,6 @@ interface ErrorHandler {
     handleErrors: ErrorHandlerFunction;
 }
 
-// TODO: Remove when handleErrors is properly moved (and possibly reworked) to Core from EchoPedia
 export const errorHandler = ((): ErrorHandler => {
     let errorHandlerFunction: ErrorHandlerFunction | undefined;
 

--- a/packages/echo-core/src/utils/module.ts
+++ b/packages/echo-core/src/utils/module.ts
@@ -6,6 +6,7 @@ export function addOrOverwrite(modules: Array<AppModule>, module: AppModule): Ap
     return [];
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function removeModuleByKey<TKey extends string>(modules: AppModule[], key: TKey): AppModule[] {
     return [];
 }


### PR DESCRIPTION
## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

-   [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
-   [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] I have updated the documentation accordingly
-   [x] I have added tests to cover my changes

### Description

Added possibility to set and call an errorHandler function on EchoCore: on the long run the goal would be to be able to decouple ayelix completely from echopediaWeb.

With this change `echopediaWeb` will be responsible to call `EchoCore.setErrorHandler()` function on Echo app initialization, so it can be called by other Echo Apps / Modules.
This is meant to be an intermediate step before moving (and possible reworking) the `handleErrors()` function itself.

Some extra: Fixed some lint errors as well.

This PR contains a fraction of these dependencies, expect more to come.

### Related PR:
See the current draft PR in Echopedia for usage and setup in case of ayelix:
https://github.com/equinor/EchopediaWeb/pull/844