### PR TITLE
feat: Load module when on its path

### DIFF
--- a/packages/echo-base/package-lock.json
+++ b/packages/echo-base/package-lock.json
@@ -18,9 +18,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "14.17.18",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.18.tgz",
-            "integrity": "sha512-haYyibw4pbteEhkSg0xdDLAI3679L75EJ799ymVrPxOA922bPx3ML59SoDsQ//rHlvqpu+e36kcbR3XRQtFblA==",
+            "version": "14.17.32",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
+            "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
             "dev": true
         },
         "node_modules/at-least-node": {
@@ -91,9 +91,9 @@
             "dev": true
         },
         "node_modules/glob": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -175,9 +175,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-            "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
             "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
@@ -346,9 +346,9 @@
             }
         },
         "node_modules/shiki": {
-            "version": "0.9.11",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.11.tgz",
-            "integrity": "sha512-tjruNTLFhU0hruCPoJP0y+B9LKOmcqUhTpxn7pcJB3fa+04gFChuEmxmrUfOJ7ZO6Jd+HwMnDHgY3lv3Tqonuw==",
+            "version": "0.9.12",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.12.tgz",
+            "integrity": "sha512-VXcROdldv0/Qu0w2XvzU4IrvTeBNs/Kj/FCmtcEXGz7Tic/veQzliJj6tEiAgoKianhQstpYmbPDStHU5Opqcw==",
             "dev": true,
             "dependencies": {
                 "jsonc-parser": "^3.0.0",
@@ -421,9 +421,9 @@
             }
         },
         "node_modules/uglify-js": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.2.tgz",
-            "integrity": "sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==",
+            "version": "3.14.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.3.tgz",
+            "integrity": "sha512-mic3aOdiq01DuSVx0TseaEzMIVqebMZ0Z3vaeDhFEh9bsc24hV1TFvN74reA2vs08D0ZWfNjAcJ3UbVLaBss+g==",
             "dev": true,
             "optional": true,
             "bin": {
@@ -469,9 +469,9 @@
     },
     "dependencies": {
         "@types/node": {
-            "version": "14.17.18",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.18.tgz",
-            "integrity": "sha512-haYyibw4pbteEhkSg0xdDLAI3679L75EJ799ymVrPxOA922bPx3ML59SoDsQ//rHlvqpu+e36kcbR3XRQtFblA==",
+            "version": "14.17.32",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
+            "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
             "dev": true
         },
         "at-least-node": {
@@ -533,9 +533,9 @@
             "dev": true
         },
         "glob": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
@@ -597,9 +597,9 @@
             "dev": true
         },
         "is-core-module": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-            "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -736,9 +736,9 @@
             }
         },
         "shiki": {
-            "version": "0.9.11",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.11.tgz",
-            "integrity": "sha512-tjruNTLFhU0hruCPoJP0y+B9LKOmcqUhTpxn7pcJB3fa+04gFChuEmxmrUfOJ7ZO6Jd+HwMnDHgY3lv3Tqonuw==",
+            "version": "0.9.12",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.12.tgz",
+            "integrity": "sha512-VXcROdldv0/Qu0w2XvzU4IrvTeBNs/Kj/FCmtcEXGz7Tic/veQzliJj6tEiAgoKianhQstpYmbPDStHU5Opqcw==",
             "dev": true,
             "requires": {
                 "jsonc-parser": "^3.0.0",
@@ -789,9 +789,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.2.tgz",
-            "integrity": "sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==",
+            "version": "3.14.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.3.tgz",
+            "integrity": "sha512-mic3aOdiq01DuSVx0TseaEzMIVqebMZ0Z3vaeDhFEh9bsc24hV1TFvN74reA2vs08D0ZWfNjAcJ3UbVLaBss+g==",
             "dev": true,
             "optional": true
         },

--- a/packages/echo-base/src/module/create.ts
+++ b/packages/echo-base/src/module/create.ts
@@ -18,7 +18,7 @@ interface StartLoadingModules {
  * @param {LoadingModuleOptions} options
  * @return {*}  {StartLoadingModules}
  */
-export function startLoadingModules(options: LoadingModuleOptions): StartLoadingModules {
+export function startLoadingModules(options: LoadingModuleOptions, currentPath: string): StartLoadingModules {
     const state = {
         loaded: false,
         modules: [],
@@ -39,7 +39,7 @@ export function startLoadingModules(options: LoadingModuleOptions): StartLoading
         notify();
     };
 
-    fireAndForget(() => standardStrategy(options, setAppModules).then(setLoaded, setLoaded));
+    fireAndForget(() => standardStrategy(options, setAppModules, currentPath).then(setLoaded, setLoaded));
 
     return {
         connect(notifier: EchoModulesLoading): void {

--- a/packages/echo-base/src/module/loader.ts
+++ b/packages/echo-base/src/module/loader.ts
@@ -23,12 +23,13 @@ const inBrowser = typeof document !== 'undefined';
  * @return {*}  {ModuleLoader}
  */
 export function createModuleLoader(
+    currentPath: string,
     config?: DefaultLoaderConfig,
     dependencies?: AvailableDependencies,
     getDependencies?: AppDependencyGetter
 ): ModuleLoader {
     const getDeps = getDependencyResolver(dependencies, getDependencies);
-    return getModuleLoader(getDeps, config);
+    return getModuleLoader(currentPath, getDeps, config);
 }
 
 /**
@@ -40,15 +41,20 @@ export function createModuleLoader(
  * @param {DefaultLoaderConfig} [config={}]
  * @return {*}  {ModuleLoader}
  */
-export function getModuleLoader(getDependencies: AppDependencyGetter, config: DefaultLoaderConfig = {}): ModuleLoader {
+export function getModuleLoader(
+    currentPath: string,
+    getDependencies: AppDependencyGetter,
+    config: DefaultLoaderConfig = {}
+): ModuleLoader {
     return (meta: ModuleMetaData): Promise<EchoModule> => {
-        if (inBrowser && 'requireRef' in meta && meta.requireRef) {
+        const hasRequireRef = inBrowser && 'requireRef' in meta && meta.requireRef;
+        if (hasRequireRef && meta.path === currentPath) {
             return loadModule(meta, getDependencies, (deps) =>
                 includeModuleWithDependencies(meta, deps, config.crossOrigin)
             );
         }
 
-        console.warn('Empty Module found!', meta.name);
+        !hasRequireRef && console.warn('Empty Module found!', meta.name);
         return Promise.resolve(createEmptyModule(meta));
     };
 }

--- a/packages/echo-base/src/module/strategies.ts
+++ b/packages/echo-base/src/module/strategies.ts
@@ -51,8 +51,17 @@ async function evaluateAllModules(
  * @param {EchoModuleLoaded} callback
  * @return {*}  {Promise<void>}
  */
-export async function standardStrategy(options: LoadingModuleOptions, callback: EchoModuleLoaded): Promise<void> {
-    const loader: ModuleLoader = createModuleLoader(options.config, options.dependencies, options.getDependencies);
+export async function standardStrategy(
+    options: LoadingModuleOptions,
+    callback: EchoModuleLoaded,
+    currentPath: string
+): Promise<void> {
+    const loader: ModuleLoader = createModuleLoader(
+        currentPath,
+        options.config,
+        options.dependencies,
+        options.getDependencies
+    );
     try {
         const fetchedModules = await loadModules(loader, options.fetchModules);
         const allModules = await evaluateAllModules(options.createApi, fetchedModules, options.modules);

--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.3.27",
+    "version": "0.3.28",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.3.27",
+            "version": "0.3.28",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "2.8.0",
@@ -19,7 +19,7 @@
                 "@babel/preset-env": "^7.12.11",
                 "@babel/preset-react": "^7.12.10",
                 "@babel/preset-typescript": "^7.12.7",
-                "@equinor/echo-base": "^0.3.0",
+                "@equinor/echo-base": "^0.3.4",
                 "@microsoft/microsoft-graph-types": "^1.20.0",
                 "@rollup/plugin-node-resolve": "^11.0.1",
                 "@rollup/plugin-typescript": "^8.0.0",
@@ -50,7 +50,7 @@
                 "typescript": "^4.1.2"
             },
             "peerDependencies": {
-                "@equinor/echo-base": "^0.3.0",
+                "@equinor/echo-base": "^0.3.4",
                 "react": ">=17.0.2",
                 "react-dom": ">=17.0.2",
                 "react-router": ">=5.2.0",
@@ -1764,9 +1764,9 @@
             }
         },
         "node_modules/@equinor/echo-base": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.3.3.tgz",
-            "integrity": "sha512-d44nQt9vTmuKAZ0P3Vt5MPd2C68RdumOHG0R74qDxAd16M+ZZfFXw8TbEv8GjuPy1WyMy+X3jlXDzz5NYJp1pQ==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.3.4.tgz",
+            "integrity": "sha512-3dZVrxiQAyKlJcvi+BllsTN8FMDXYOAY9KmHmjWTPxSrUcx9/GbnFMrt+YDF8TwmzJtZoyKR5ghN69qN39JhOQ==",
             "dev": true,
             "dependencies": {
                 "tslib": "^2.2.0"
@@ -7087,9 +7087,9 @@
             }
         },
         "@equinor/echo-base": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.3.3.tgz",
-            "integrity": "sha512-d44nQt9vTmuKAZ0P3Vt5MPd2C68RdumOHG0R74qDxAd16M+ZZfFXw8TbEv8GjuPy1WyMy+X3jlXDzz5NYJp1pQ==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.3.4.tgz",
+            "integrity": "sha512-3dZVrxiQAyKlJcvi+BllsTN8FMDXYOAY9KmHmjWTPxSrUcx9/GbnFMrt+YDF8TwmzJtZoyKR5ghN69qN39JhOQ==",
             "dev": true,
             "requires": {
                 "tslib": "^2.2.0"

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.3.27",
+    "version": "0.3.28",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
@@ -29,7 +29,7 @@
         "directory": "packages/echo-core"
     },
     "peerDependencies": {
-        "@equinor/echo-base": "^0.3.0",
+        "@equinor/echo-base": "^0.3.4",
         "react": ">=17.0.2",
         "react-dom": ">=17.0.2",
         "react-router": ">=5.2.0",
@@ -46,7 +46,7 @@
         "@babel/preset-env": "^7.12.11",
         "@babel/preset-react": "^7.12.10",
         "@babel/preset-typescript": "^7.12.7",
-        "@equinor/echo-base": "^0.3.0",
+        "@equinor/echo-base": "^0.3.4",
         "@microsoft/microsoft-graph-types": "^1.20.0",
         "@rollup/plugin-node-resolve": "^11.0.1",
         "@rollup/plugin-typescript": "^8.0.0",


### PR DESCRIPTION
### Description

We only want to start the process of loading a module when we are on that module's path. This is a suggestion of how we can achieve that. The mediator from Core (which calls the `startLoadingModules` function) will provide the current path. Which we use here to decide if we want to load the module or not.

### Remarks

This is only a suggestion, and maybe a step in the right direction. We might want to look more into unloading modules as well, but this could be more of an MVP.

## How to test
You need both this branch, and the [related branch](https://github.com/equinor/EchoFramework/pull/79) in EchoFramework for this to work.

In echo-base do:

```
npm run build
yalc publish
```
In echo-framework do:
```
yalc add @equinor/echo-base
npm install
npm run build
yalc publish
```
In EchopediaWeb do:
```
yalc add @equinor/echo-framework
yalc add @equinor/echo-base
npm install
```
If you get an error when trying to start the application, try to copy the `dist` folder from echo-framework, and place it under the folder `.yalc/@equinor/echo-framework` in echopedia-web.

Now try to start again.

When the app has started, open the network tab, and in the filter write "echo3d". The echoModuleManifest.json should be fetched on startup, but the index.js should not. If you open echo3dWeb, you should see that the index.js file is fetched.


## Related PRs

https://github.com/equinor/EchoFramework/pull/79