### PR TITLE
refactor: Replace react router with react router dom

### DIFF
--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.3.29",
+    "version": "0.3.30",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.3.29",
+            "version": "0.3.30",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "2.8.0",

--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.3.28",
+    "version": "0.3.29",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.3.28",
+            "version": "0.3.29",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "2.8.0",
@@ -34,7 +34,6 @@
                 "eslint-plugin-react-hooks": "^4.1.2",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
-                "react-router": "^5.2.0",
                 "react-router-dom": "^5.2.0",
                 "react-test-renderer": "^17.0.1",
                 "rollup": "^2.34.1",
@@ -53,7 +52,6 @@
                 "@equinor/echo-base": "^0.3.4",
                 "react": ">=17.0.2",
                 "react-dom": ">=17.0.2",
-                "react-router": ">=5.2.0",
                 "react-router-dom": ">=5.2.0"
             }
         },

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.3.30",
+    "version": "0.3.31",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -32,7 +32,6 @@
         "@equinor/echo-base": "^0.3.4",
         "react": ">=17.0.2",
         "react-dom": ">=17.0.2",
-        "react-router": ">=5.2.0",
         "react-router-dom": ">=5.2.0"
     },
     "dependencies": {
@@ -61,7 +60,6 @@
         "eslint-plugin-react-hooks": "^4.1.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
         "react-test-renderer": "^17.0.1",
         "rollup": "^2.34.1",

--- a/packages/echo-core/rollup.config.js
+++ b/packages/echo-core/rollup.config.js
@@ -16,7 +16,7 @@ export default [
             format: 'cjs',
             exports: 'named'
         },
-        external: ['react', 'react-dom', 'react-router', '@equinor/echo-base', '@azure/msal-browser'],
+        external: ['react', 'react-dom', 'react-router-dom', '@equinor/echo-base', '@azure/msal-browser'],
         plugins: [
             tslibResolveId(),
             del({ targets: 'dist/*', runOnce: true }),

--- a/packages/echo-core/src/hooks/useInternalLink.ts
+++ b/packages/echo-core/src/hooks/useInternalLink.ts
@@ -1,4 +1,4 @@
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { createOfflineMessage } from '../message/message';
 import { AppLinkOptions } from '../types/registry';
 import { useEchoEventHub } from './useEchoEventHub';


### PR DESCRIPTION
### Description

We don't need react-router as a peer dependency in echo-core. This was also causing some issues when building EchopediaWeb, complaining that we don't have it installed as a dependency there.

Removing it, and replacing it with react-router-dom.