### PR TITLE
feat!: #55685 Revert load on path changes

### DIFF
--- a/packages/echo-base/package-lock.json
+++ b/packages/echo-base/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-base",
-    "version": "0.3.4",
+    "version": "0.4.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-base",
-            "version": "0.3.4",
+            "version": "0.4.0",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.2.0"

--- a/packages/echo-base/package.json
+++ b/packages/echo-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-base",
-    "version": "0.3.4",
+    "version": "0.4.0",
     "module": "esm/index.js",
     "main": "lib/index.js",
     "typings": "lib/index.d.ts",

--- a/packages/echo-base/src/module/create.ts
+++ b/packages/echo-base/src/module/create.ts
@@ -18,7 +18,7 @@ interface StartLoadingModules {
  * @param {LoadingModuleOptions} options
  * @return {*}  {StartLoadingModules}
  */
-export function startLoadingModules(options: LoadingModuleOptions, currentPath: string): StartLoadingModules {
+export function startLoadingModules(options: LoadingModuleOptions): StartLoadingModules {
     const state = {
         loaded: false,
         modules: [],
@@ -39,7 +39,7 @@ export function startLoadingModules(options: LoadingModuleOptions, currentPath: 
         notify();
     };
 
-    fireAndForget(() => standardStrategy(options, setAppModules, currentPath).then(setLoaded, setLoaded));
+    fireAndForget(() => standardStrategy(options, setAppModules).then(setLoaded, setLoaded));
 
     return {
         connect(notifier: EchoModulesLoading): void {

--- a/packages/echo-base/src/module/loader.ts
+++ b/packages/echo-base/src/module/loader.ts
@@ -23,13 +23,12 @@ const inBrowser = typeof document !== 'undefined';
  * @return {*}  {ModuleLoader}
  */
 export function createModuleLoader(
-    currentPath: string,
     config?: DefaultLoaderConfig,
     dependencies?: AvailableDependencies,
     getDependencies?: AppDependencyGetter
 ): ModuleLoader {
     const getDeps = getDependencyResolver(dependencies, getDependencies);
-    return getModuleLoader(currentPath, getDeps, config);
+    return getModuleLoader(getDeps, config);
 }
 
 /**
@@ -42,19 +41,18 @@ export function createModuleLoader(
  * @return {*}  {ModuleLoader}
  */
 export function getModuleLoader(
-    currentPath: string,
     getDependencies: AppDependencyGetter,
     config: DefaultLoaderConfig = {}
 ): ModuleLoader {
     return (meta: ModuleMetaData): Promise<EchoModule> => {
         const hasRequireRef = inBrowser && 'requireRef' in meta && meta.requireRef;
-        if (hasRequireRef && meta.path === currentPath) {
+        if (hasRequireRef) {
             return loadModule(meta, getDependencies, (deps) =>
                 includeModuleWithDependencies(meta, deps, config.crossOrigin)
             );
         }
 
-        !hasRequireRef && console.warn('Empty Module found!', meta.name);
+        console.warn('Empty Module found!', meta.name);
         return Promise.resolve(createEmptyModule(meta));
     };
 }

--- a/packages/echo-base/src/module/strategies.ts
+++ b/packages/echo-base/src/module/strategies.ts
@@ -53,11 +53,9 @@ async function evaluateAllModules(
  */
 export async function standardStrategy(
     options: LoadingModuleOptions,
-    callback: EchoModuleLoaded,
-    currentPath: string
+    callback: EchoModuleLoaded
 ): Promise<void> {
     const loader: ModuleLoader = createModuleLoader(
-        currentPath,
         options.config,
         options.dependencies,
         options.getDependencies


### PR DESCRIPTION
## Prerequisites

Please make sure you can check the following boxes:

-   [ ] My code follows the code style of this project
-   [ ] All new and existing tests passed
-   [ ] Fix any eslint/prettier warnings/errors: npm run lint
-   [ ] Remove unnecessary console.log (use logInfo logWarn if it's needed)
-   [ ] Are variable and function names properly describing what it does?

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

-   [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
-   [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] I have updated the documentation accordingly
-   [ ] I have added tests to cover my changes

### Description

First part of adding optional lazy loading for echo apps: removing the previously added load module only if on path feature.
https://github.com/equinor/EchoCore/pull/83

### Related PRs
Framework:
Adding a loading indicator for lazy loaded applications https://github.com/equinor/EchoFramework/pull/92