### PR TITLE
fix!: BaseError innerException name/message

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # EchoCore
 
 A monorepo with all tools needed to communicate with echo framework. the repo contains two packages.
-You can read more about them in the links below
+You can read more about them in the links below, which also includes breaking changes (new since v0.5.0).
 
 -   [@equinor/echo-base](https://github.com/equinor/EchoCore/blob/main/packages/echo-base)
 -   [@equinor/echo-core](https://github.com/equinor/EchoCore/blob/main/packages/echo-core)

--- a/packages/echo-base/README.md
+++ b/packages/echo-base/README.md
@@ -13,3 +13,7 @@ Everything a Echo web need for enabling micro frontend development.
 ![@equinor/echo-base](https://badgen.net/bundlephobia/dependency-count/@equinor/echo-base)
 
 ## Documentation
+
+# Breaking Changes
+
+-   v0.5.0: SubClasses of NetworkError will not get the name of the class automatically anymore, but will instead get the parentName if the optional name field is not specified. This to avoid name obfuscation/minify to a single letter in appInsight.

--- a/packages/echo-base/README.md
+++ b/packages/echo-base/README.md
@@ -16,4 +16,16 @@ Everything a Echo web need for enabling micro frontend development.
 
 # Breaking Changes
 
--   v0.5.0: SubClasses of NetworkError will not get the name of the class automatically anymore, but will instead get the parentName if the optional name field is not specified. This to avoid name obfuscation/minify to a single letter in appInsight.
+v0.5.0:
+
+-   SubClasses of BaseError will not get the name of the class automatically anymore, but have to specify it. This to avoid name obfuscation/minify to a single letter in appInsight.
+
+Example implementation:
+
+```
+export class CustomError extends BaseError {
+    constructor(args: ErrorArgs) {
+        super({ ...args, name: 'CustomError' });
+    }
+}
+```

--- a/packages/echo-base/package-lock.json
+++ b/packages/echo-base/package-lock.json
@@ -9,12 +9,12 @@
             "version": "0.5.0",
             "license": "MIT",
             "dependencies": {
-                "tslib": "^2.2.0"
+                "tslib": "^2.3.1"
             },
             "devDependencies": {
                 "@types/node": "^14.14.37",
                 "typedoc": "^0.20.35",
-                "typescript": "^4.2.4"
+                "typescript": "^4.4.4"
             }
         },
         "node_modules/@types/node": {
@@ -408,9 +408,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-            "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+            "version": "4.5.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+            "integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -783,9 +783,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-            "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+            "version": "4.5.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+            "integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
             "dev": true
         },
         "uglify-js": {

--- a/packages/echo-base/package-lock.json
+++ b/packages/echo-base/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-base",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-base",
-            "version": "0.4.0",
+            "version": "0.5.0",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.2.0"

--- a/packages/echo-base/package.json
+++ b/packages/echo-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-base",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "module": "esm/index.js",
     "main": "lib/index.js",
     "typings": "lib/index.d.ts",

--- a/packages/echo-base/package.json
+++ b/packages/echo-base/package.json
@@ -32,7 +32,7 @@
     "devDependencies": {
         "@types/node": "^14.14.37",
         "typedoc": "^0.20.35",
-        "typescript": "^4.2.4"
+        "typescript": "^4.4.4"
     },
     "files": [
         "esm",
@@ -40,6 +40,6 @@
         "src"
     ],
     "dependencies": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     }
 }

--- a/packages/echo-base/src/__tests__/errors/NetworkError.test.ts
+++ b/packages/echo-base/src/__tests__/errors/NetworkError.test.ts
@@ -1,4 +1,14 @@
-import { ForbiddenError, NetworkError, NetworkErrorArgs } from '../../errors/NetworkError';
+import { BaseError } from '../../errors';
+import {
+    BackendError,
+    BadRequestError,
+    ForbiddenError,
+    NetworkError,
+    NetworkErrorArgs,
+    NotFoundError,
+    UnauthorizedError,
+    ValidationError
+} from '../../errors/NetworkError';
 
 describe('NetworkError', () => {
     const message = 'Network Error Testing';
@@ -39,5 +49,45 @@ describe('NetworkError', () => {
     it('check BaseError name when message is not empty', () => {
         const ne = new NetworkError({ message, httpStatusCode, url, exception });
         expect(ne.message).not.toEqual(ne.name);
+    });
+});
+
+describe('NetworkError & subclasses', () => {
+    const message = 'Network Error Testing';
+    const httpStatusCode = 500;
+    const url = 'http://localhost:3000';
+    const exception = { NetworkException: 'endpoint is unreachable' };
+
+    const networkArgs = { message, httpStatusCode, url, exception };
+    const expectedProperties = { httpStatusCode, url, ...exception };
+
+    test.each([
+        ['NetworkError', new NetworkError(networkArgs)],
+        ['BadRequestError', new BadRequestError(networkArgs)],
+        ['ForbiddenError', new ForbiddenError(networkArgs)],
+        ['UnauthorizedError', new UnauthorizedError(networkArgs)],
+        ['NotFoundError', new NotFoundError(networkArgs)],
+        ['ValidationError', new ValidationError(networkArgs)],
+        ['BackendError', new BackendError(networkArgs)]
+    ])('%p should preserve default name, message and properties', (firstArg, secondArg) => {
+        const error = secondArg as BaseError;
+        expect(error.name).toBe(firstArg);
+        expect(error.message).toBe(message);
+        expect(error.getProperties()).toStrictEqual(expectedProperties);
+    });
+
+    test.each([
+        ['NetworkError', new NetworkError({ name: 'CustomTestName', ...networkArgs })],
+        ['BadRequestError', new BadRequestError({ name: 'CustomTestName', ...networkArgs })],
+        ['ForbiddenError', new ForbiddenError({ name: 'CustomTestName', ...networkArgs })],
+        ['UnauthorizedError', new UnauthorizedError({ name: 'CustomTestName', ...networkArgs })],
+        ['NotFoundError', new NotFoundError({ name: 'CustomTestName', ...networkArgs })],
+        ['ValidationError', new ValidationError({ name: 'CustomTestName', ...networkArgs })],
+        ['BackendError', new BackendError({ name: 'CustomTestName', ...networkArgs })]
+    ])('%p should preserve _custom_ name, message and properties', (firstArg, secondArg) => {
+        const error = secondArg as BaseError;
+        expect(error.name).toBe('CustomTestName');
+        expect(error.message).toBe(message);
+        expect(error.getProperties()).toStrictEqual(expectedProperties);
     });
 });

--- a/packages/echo-base/src/__tests__/errors/errorHandlers.test.ts
+++ b/packages/echo-base/src/__tests__/errors/errorHandlers.test.ts
@@ -143,4 +143,8 @@ describe('NetworkError, derived types and initializeError', () => {
     });
 });
 
-class InternalError extends NetworkError {}
+class InternalError extends NetworkError {
+    constructor(args: NetworkErrorArgs) {
+        super({ ...args, name: args.name ?? 'InternalError' });
+    }
+}

--- a/packages/echo-base/src/__tests__/module/strategies.test.ts
+++ b/packages/echo-base/src/__tests__/module/strategies.test.ts
@@ -15,22 +15,25 @@ describe('Echo-Base strategies module', () => {
         // Arrange
         const setupMock = jest.fn();
         const callbackMock = jest.fn();
+
         const appModule = [
             {
                 setup: setupMock,
                 key: 'sA1',
                 name: 'someApp',
+                shortName: 'someApp',
+                path: '/',
                 fileUri: 'file.js',
-                version: '1',
-                shortName: 'someApp'
+                version: '1'
             },
             {
                 setup: setupMock,
                 key: 'sA2',
                 name: 'someApp',
+                shortName: 'someApp',
+                path: '/',
                 fileUri: 'file.js',
-                version: '1',
-                shortName: 'someApp'
+                version: '1'
             }
         ] as EchoModule[];
         const loadingOptions: LoadingModuleOptions = {

--- a/packages/echo-base/src/__tests__/module/strategies.test.ts
+++ b/packages/echo-base/src/__tests__/module/strategies.test.ts
@@ -1,4 +1,4 @@
-import { ModulesEvaluationError } from '../../module/errors';
+import { BaseError } from '../../errors';
 import { standardStrategy } from '../../module/strategies';
 import { EchoModule, EchoModuleApi, EchoModuleApiCreator, LoadingModuleOptions, ModuleMetaData } from '../../types';
 import { eventHub } from '../../utils/eventHub';
@@ -76,9 +76,8 @@ describe('Echo-Base strategies module', () => {
     });
 
     it('standardStrategy reports error if failed due to invalid arguments', async () => {
-        const setupMock = jest.fn();
-        const callbackMock = jest.fn();
-        const error = new ModulesEvaluationError({ message: 'oldModules is not iterable' });
+        // given
+        let actualError: BaseError;
         const modules = true as any;
         const invalidLoadModuleOptions: LoadingModuleOptions = {
             createApi: createMockApi(),
@@ -86,9 +85,15 @@ describe('Echo-Base strategies module', () => {
             modules
         };
 
-        await standardStrategy(invalidLoadModuleOptions, callbackMock);
+        // when
+        await standardStrategy(invalidLoadModuleOptions, (error) => (actualError = error));
 
-        expect(setupMock).toHaveBeenCalledTimes(0);
-        expect(callbackMock).toHaveBeenCalledWith(error, []);
+        // then
+        expect(actualError.name).toBe('ModulesEvaluationError');
+        expect(actualError.message).toBe('[strategies.evaluateAllModules] failed');
+
+        const actualProperties = actualError.getProperties();
+        expect(actualProperties['name']).toBe('TypeError');
+        expect(actualProperties['message']).toBe('oldModules is not iterable');
     });
 });

--- a/packages/echo-base/src/errors/ArgumentError.ts
+++ b/packages/echo-base/src/errors/ArgumentError.ts
@@ -6,7 +6,7 @@ export interface ArgumentErrorArgs {
 
 export class ArgumentError extends BaseError {
     constructor({ argumentName }: ArgumentErrorArgs) {
-        super({ message: argumentName });
+        super({ name: 'ArgumentError', message: argumentName });
     }
 }
 

--- a/packages/echo-base/src/errors/BaseError.test.ts
+++ b/packages/echo-base/src/errors/BaseError.test.ts
@@ -1,0 +1,68 @@
+import { BaseError, getAllProperties } from './BaseError';
+
+describe('BaseError', () => {
+    const message = 'this is a test';
+    it('should initialize with correct values', () => {
+        const actualError = new BaseError({ message });
+        expect(actualError.message).toBe(message);
+        expect(actualError.name).toBe('BaseError');
+        expect(actualError.stack).toBeTruthy();
+    });
+
+    it('should preserve innerError as properties', () => {
+        const innerMessage = 'message';
+        const innerException = new CustomError(innerMessage);
+        const actualError = new BaseError({ message, exception: innerException });
+        expect(actualError.message).toBe(message);
+        expect(actualError.name).toBe('BaseError');
+        expect(actualError.stack).toBeTruthy();
+
+        const actualProperties = actualError.getProperties();
+        actualProperties.stack = actualProperties.stack ? 'stack' : actualProperties.stack;
+        const expected = customErrorExpected();
+        expect(actualProperties).toStrictEqual(expected);
+    });
+});
+
+describe('getAllProperties', () => {
+    const input = { a: 'a', b: 1, c: { nestedProp: 'prop1' } };
+
+    it('should return an empty object if undefined argument', () => {
+        const actualError = getAllProperties(undefined);
+        expect(actualError).toStrictEqual({});
+    });
+    it('should preserve properties of different types', () => {
+        const actualError = getAllProperties(input);
+        expect(actualError).toStrictEqual(input);
+    });
+
+    it('should preserve properties of an Error', () => {
+        const actualError = getAllProperties(new CustomError('message'));
+        const expected = customErrorExpected();
+        actualError.stack = actualError.stack ? 'stack' : actualError.stack;
+        expect(actualError).toStrictEqual(expected);
+    });
+});
+
+class CustomError extends Error {
+    anotherField: string;
+    constructor(message: string) {
+        super(message);
+        this.name = 'CustomError2';
+        this.anotherField = 'another value';
+    }
+}
+
+function customErrorExpected(): {
+    name: string;
+    anotherField: string;
+    message: string;
+    stack: string;
+} {
+    return {
+        name: 'CustomError2',
+        anotherField: 'another value',
+        message: 'message',
+        stack: 'stack'
+    };
+}

--- a/packages/echo-base/src/errors/BaseError.test.ts
+++ b/packages/echo-base/src/errors/BaseError.test.ts
@@ -1,26 +1,33 @@
 import { BaseError, getAllProperties } from './BaseError';
 
 describe('BaseError', () => {
-    const message = 'this is a test';
+    const message = 'This is a custom error message for testing';
+
     it('should initialize with correct values', () => {
         const actualError = new BaseError({ name: 'BaseError', message });
+
         expect(actualError.message).toBe(message);
         expect(actualError.name).toBe('BaseError');
         expect(actualError.stack).toBeTruthy();
     });
 
     it('should preserve innerError as properties', () => {
-        const innerMessage = 'message';
-        const innerException = new CustomError(innerMessage);
-        const actualError = new BaseError({ name: 'BaseError', message, exception: innerException });
+        const innerMessage = 'inner message';
+        const innerError = new CustomTestError(innerMessage);
+        const actualError = new BaseError({ name: 'BaseError', message, exception: innerError });
+
         expect(actualError.message).toBe(message);
         expect(actualError.name).toBe('BaseError');
         expect(actualError.stack).toBeTruthy();
 
         const actualProperties = actualError.getProperties();
         actualProperties.stack = actualProperties.stack ? 'stack' : actualProperties.stack;
-        const expected = customErrorExpected();
-        expect(actualProperties).toStrictEqual(expected);
+        expect(actualProperties).toStrictEqual({
+            name: 'CustomTestError',
+            anotherField: 'another value',
+            message: innerMessage,
+            stack: 'stack'
+        });
     });
 });
 
@@ -31,38 +38,30 @@ describe('getAllProperties', () => {
         const actualError = getAllProperties(undefined);
         expect(actualError).toStrictEqual({});
     });
+
     it('should preserve properties of different types', () => {
         const actualError = getAllProperties(input);
         expect(actualError).toStrictEqual(input);
     });
 
     it('should preserve properties of an Error', () => {
-        const actualError = getAllProperties(new CustomError('message'));
-        const expected = customErrorExpected();
+        const actualError = getAllProperties(new CustomTestError('message'));
+
         actualError.stack = actualError.stack ? 'stack' : actualError.stack;
-        expect(actualError).toStrictEqual(expected);
+        expect(actualError).toStrictEqual({
+            name: 'CustomTestError',
+            anotherField: 'another value',
+            message: 'message',
+            stack: 'stack'
+        });
     });
 });
 
-class CustomError extends Error {
+class CustomTestError extends Error {
     anotherField: string;
     constructor(message: string) {
         super(message);
-        this.name = 'CustomError';
+        this.name = 'CustomTestError';
         this.anotherField = 'another value';
     }
-}
-
-function customErrorExpected(): {
-    name: string;
-    anotherField: string;
-    message: string;
-    stack: string;
-} {
-    return {
-        name: 'CustomError',
-        anotherField: 'another value',
-        message: 'message',
-        stack: 'stack'
-    };
 }

--- a/packages/echo-base/src/errors/BaseError.test.ts
+++ b/packages/echo-base/src/errors/BaseError.test.ts
@@ -48,7 +48,7 @@ class CustomError extends Error {
     anotherField: string;
     constructor(message: string) {
         super(message);
-        this.name = 'CustomError2';
+        this.name = 'CustomError';
         this.anotherField = 'another value';
     }
 }
@@ -60,7 +60,7 @@ function customErrorExpected(): {
     stack: string;
 } {
     return {
-        name: 'CustomError2',
+        name: 'CustomError',
         anotherField: 'another value',
         message: 'message',
         stack: 'stack'

--- a/packages/echo-base/src/errors/BaseError.test.ts
+++ b/packages/echo-base/src/errors/BaseError.test.ts
@@ -3,7 +3,7 @@ import { BaseError, getAllProperties } from './BaseError';
 describe('BaseError', () => {
     const message = 'this is a test';
     it('should initialize with correct values', () => {
-        const actualError = new BaseError({ message });
+        const actualError = new BaseError({ name: 'BaseError', message });
         expect(actualError.message).toBe(message);
         expect(actualError.name).toBe('BaseError');
         expect(actualError.stack).toBeTruthy();
@@ -12,7 +12,7 @@ describe('BaseError', () => {
     it('should preserve innerError as properties', () => {
         const innerMessage = 'message';
         const innerException = new CustomError(innerMessage);
-        const actualError = new BaseError({ message, exception: innerException });
+        const actualError = new BaseError({ name: 'BaseError', message, exception: innerException });
         expect(actualError.message).toBe(message);
         expect(actualError.name).toBe('BaseError');
         expect(actualError.stack).toBeTruthy();

--- a/packages/echo-base/src/errors/BaseError.ts
+++ b/packages/echo-base/src/errors/BaseError.ts
@@ -15,7 +15,7 @@ export class BaseError extends Error {
     protected properties: ErrorProperties;
     hasBeenLogged = false;
 
-    constructor({ message, exception }: BaseErrorArgs) {
+    constructor({ name, message, exception }: BaseErrorArgs) {
         super(message);
         /**
          * Object.setPrototypeOf(this, new.target.prototype);: to fix instance of:
@@ -25,7 +25,7 @@ export class BaseError extends Error {
         Object.setPrototypeOf(this, new.target.prototype);
 
         this.properties = getAllProperties(exception);
-        this.name = this.constructor.name;
+        this.name = name ?? this.constructor.name;
         !message && (this.message = this.name);
     }
 

--- a/packages/echo-base/src/errors/BaseError.ts
+++ b/packages/echo-base/src/errors/BaseError.ts
@@ -22,9 +22,9 @@ export class BaseError extends Error {
          * https://stackoverflow.com/questions/55065742/implementing-instanceof-checks-for-custom-typescript-error-instances
          * https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
          */
-
         Object.setPrototypeOf(this, new.target.prototype);
-        this.properties = exception ? { ...exception } : {};
+
+        this.properties = getAllProperties(exception);
         this.name = this.constructor.name;
         !message && (this.message = this.name);
     }
@@ -34,4 +34,11 @@ export class BaseError extends Error {
     addProperties = (values: ErrorProperties): void => {
         this.properties = { ...this.properties, ...values };
     };
+}
+
+export function getAllProperties(
+    objectWithProperties: Record<string, unknown> | Error | undefined
+): Record<string, unknown> {
+    const names = objectWithProperties ? Object.getOwnPropertyNames(objectWithProperties) : [];
+    return names.reduce((a, b) => ((a[b] = objectWithProperties[b]), a), {});
 }

--- a/packages/echo-base/src/errors/NetworkError.ts
+++ b/packages/echo-base/src/errors/NetworkError.ts
@@ -2,6 +2,7 @@ import { CommonErrorArgs } from '../types/error';
 import { BaseError } from './BaseError';
 
 export interface NetworkErrorArgs extends CommonErrorArgs {
+    name?: string;
     exception?: Record<string, unknown>;
     httpStatusCode: number;
     url: string;
@@ -19,8 +20,8 @@ export interface NetworkErrorArgs extends CommonErrorArgs {
  * @extends {BaseError}
  */
 export class NetworkError extends BaseError {
-    constructor({ message, httpStatusCode, url, exception }: NetworkErrorArgs) {
-        super({ message: message || '', exception });
+    constructor({ name, message, httpStatusCode, url, exception }: NetworkErrorArgs) {
+        super({ name: name ?? 'NetworkError', message: message || '', exception });
         this.addProperties({ url, httpStatusCode });
         !message && (this.message = `${this.name} ${httpStatusCode} ${url}`);
     }
@@ -30,9 +31,34 @@ export class NetworkError extends BaseError {
     };
 }
 
-export class BadRequestError extends NetworkError {}
-export class BackendError extends NetworkError {}
-export class ForbiddenError extends NetworkError {}
-export class UnauthorizedError extends ForbiddenError {}
-export class NotFoundError extends NetworkError {}
-export class ValidationError extends NetworkError {}
+export class BadRequestError extends NetworkError {
+    constructor(args: NetworkErrorArgs) {
+        super({ ...args, name: args.name ?? 'BadRequestError' });
+    }
+}
+
+export class BackendError extends NetworkError {
+    constructor(args: NetworkErrorArgs) {
+        super({ ...args, name: args.name ?? 'BackendError' });
+    }
+}
+export class ForbiddenError extends NetworkError {
+    constructor(args: NetworkErrorArgs) {
+        super({ ...args, name: args.name ?? 'ForbiddenError' });
+    }
+}
+export class UnauthorizedError extends ForbiddenError {
+    constructor(args: NetworkErrorArgs) {
+        super({ ...args, name: args.name ?? 'UnauthorizedError' });
+    }
+}
+export class NotFoundError extends NetworkError {
+    constructor(args: NetworkErrorArgs) {
+        super({ ...args, name: args.name ?? 'NotFoundError' });
+    }
+}
+export class ValidationError extends NetworkError {
+    constructor(args: NetworkErrorArgs) {
+        super({ ...args, name: args.name ?? 'ValidationError' });
+    }
+}

--- a/packages/echo-base/src/errors/toError.ts
+++ b/packages/echo-base/src/errors/toError.ts
@@ -1,6 +1,11 @@
+import { ErrorArgs } from '../types/error';
 import { BaseError } from './BaseError';
 
-export class ImproperErrorObject extends BaseError {}
+export class ImproperErrorObject extends BaseError {
+    constructor(args: ErrorArgs) {
+        super({ ...args, name: 'ImproperErrorObject' });
+    }
+}
 
 /**
  * Helper method: Useful with Try Catch(error), where error is of type unknown.

--- a/packages/echo-base/src/module/errors.ts
+++ b/packages/echo-base/src/module/errors.ts
@@ -1,7 +1,19 @@
 import { BaseError } from '../errors';
+import { ErrorArgs } from '../types/error';
 
-export class ModulesMetaError extends BaseError {}
+export class ModulesMetaError extends BaseError {
+    constructor(args: ErrorArgs) {
+        super({ ...args, name: 'ModulesMetaError' });
+    }
+}
+export class ModuleLoadingError extends BaseError {
+    constructor(args: ErrorArgs) {
+        super({ ...args, name: 'ModuleLoadingError' });
+    }
+}
 
-export class ModuleLoadingError extends BaseError {}
-
-export class ModulesEvaluationError extends BaseError {}
+export class ModulesEvaluationError extends BaseError {
+    constructor(args: ErrorArgs) {
+        super({ ...args, name: 'ModulesEvaluationError' });
+    }
+}

--- a/packages/echo-base/src/module/load.ts
+++ b/packages/echo-base/src/module/load.ts
@@ -19,7 +19,7 @@ export async function loadMetaData(fetchModules?: ModuleRequester): Promise<Modu
         try {
             return verifyModulesMeta(await fetchModules());
         } catch (error) {
-            throw new ModulesMetaError(error);
+            throw new ModulesMetaError({ message: '[loadMetaData] failed', exception: error });
         }
     }
 

--- a/packages/echo-base/src/module/strategies.ts
+++ b/packages/echo-base/src/module/strategies.ts
@@ -38,7 +38,7 @@ async function evaluateAllModules(
             filterExcludePrivateModulesInProduction([...oldModules, ...newModules], isProduction)
         );
     } catch (error) {
-        throw new ModulesEvaluationError(error);
+        throw new ModulesEvaluationError({ message: '[strategies.evaluateAllModules] failed', exception: error });
     }
 }
 
@@ -51,15 +51,8 @@ async function evaluateAllModules(
  * @param {EchoModuleLoaded} callback
  * @return {*}  {Promise<void>}
  */
-export async function standardStrategy(
-    options: LoadingModuleOptions,
-    callback: EchoModuleLoaded
-): Promise<void> {
-    const loader: ModuleLoader = createModuleLoader(
-        options.config,
-        options.dependencies,
-        options.getDependencies
-    );
+export async function standardStrategy(options: LoadingModuleOptions, callback: EchoModuleLoaded): Promise<void> {
+    const loader: ModuleLoader = createModuleLoader(options.config, options.dependencies, options.getDependencies);
     try {
         const fetchedModules = await loadModules(loader, options.fetchModules);
         const allModules = await evaluateAllModules(options.createApi, fetchedModules, options.modules);

--- a/packages/echo-base/src/types/error.ts
+++ b/packages/echo-base/src/types/error.ts
@@ -14,6 +14,7 @@ export interface ErrorInitializerFunction<T extends BaseErrorProps, U extends Co
 }
 
 export interface BaseErrorArgs {
+    name?: string;
     message: string;
     exception?: Record<string, unknown> | Error;
 }

--- a/packages/echo-base/src/types/error.ts
+++ b/packages/echo-base/src/types/error.ts
@@ -13,8 +13,11 @@ export interface ErrorInitializerFunction<T extends BaseErrorProps, U extends Co
     (ErrorType: { new (args): T }, args: U): BaseErrorProps;
 }
 
-export interface BaseErrorArgs {
-    name?: string;
+export interface BaseErrorArgs extends ErrorArgs {
+    name: string;
+}
+
+export interface ErrorArgs {
     message: string;
     exception?: Record<string, unknown> | Error;
 }

--- a/packages/echo-base/src/types/error.ts
+++ b/packages/echo-base/src/types/error.ts
@@ -15,7 +15,7 @@ export interface ErrorInitializerFunction<T extends BaseErrorProps, U extends Co
 
 export interface BaseErrorArgs {
     message: string;
-    exception?: Record<string, unknown>;
+    exception?: Record<string, unknown> | Error;
 }
 
 export interface CommonErrorArgs {

--- a/packages/echo-base/src/types/loader.ts
+++ b/packages/echo-base/src/types/loader.ts
@@ -1,7 +1,12 @@
 import { BaseError } from '../errors';
+import { ErrorArgs } from './error';
 import { EchoModule, ModuleMetaData } from './module';
 
-export class ModuleAppError extends BaseError {}
+export class ModuleAppError extends BaseError {
+    constructor(args: ErrorArgs) {
+        super({ ...args, name: 'ModuleAppError' });
+    }
+}
 /**
  * Configuration options for the default loader.
  */


### PR DESCRIPTION
- BaseError now preserve the innerException name, message and stack trace, in addition to any other properties.
- BaseError now takes a name as required argument, to avoid minifying it to a single letter in appInsights.

Breaking change:
Classes that extends BaseError are now required to specify the name. It used to get the subClass name automatically, but this is not working in production because of code obfuscation/minify. 

Tested with unit tests.