### PR TITLE
fix(#57347): Offline and online not logged to app insights

### DIFF
--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/echo-core/src/services/analytics/analyticsModule.ts
+++ b/packages/echo-core/src/services/analytics/analyticsModule.ts
@@ -53,8 +53,6 @@ export class AnalyticsModule {
     }
 
     private trackOnline(): void {
-        // WILL REMOVE THIS WHEN PR IS APPROVED
-        console.log('TRACKING ONLINE --------------------------------');
         const offlineEvent = this.offlineTracker.setOnline();
         if (offlineEvent) {
             this.trackEventBy(offlineEvent.object, offlineEvent.action, {
@@ -65,8 +63,6 @@ export class AnalyticsModule {
     }
 
     private trackOffline(): void {
-        // WILL REMOVE THIS WHEN PR IS APPROVED
-        console.log('TRACKING OFFLINE --------------------------------');
         this.offlineTracker.setOffline();
     }
 

--- a/packages/echo-core/src/services/analytics/analyticsModule.ts
+++ b/packages/echo-core/src/services/analytics/analyticsModule.ts
@@ -48,11 +48,13 @@ export class AnalyticsModule {
 
         const offlineThresholdSeconds = 20;
         this.offlineTracker = new OfflineTracker(offlineThresholdSeconds, !navigator.onLine);
-        window.addEventListener('online', () => this.trackOnline);
-        window.addEventListener('offline', () => this.trackOffline);
+        window.addEventListener('online', () => this.trackOnline());
+        window.addEventListener('offline', () => this.trackOffline());
     }
 
     private trackOnline(): void {
+        // WILL REMOVE THIS WHEN PR IS APPROVED
+        console.log('TRACKING ONLINE --------------------------------');
         const offlineEvent = this.offlineTracker.setOnline();
         if (offlineEvent) {
             this.trackEventBy(offlineEvent.object, offlineEvent.action, {
@@ -63,6 +65,8 @@ export class AnalyticsModule {
     }
 
     private trackOffline(): void {
+        // WILL REMOVE THIS WHEN PR IS APPROVED
+        console.log('TRACKING OFFLINE --------------------------------');
         this.offlineTracker.setOffline();
     }
 


### PR DESCRIPTION
### Description

The functions for tracking offline and online activity were not properly called when added to the event listener.

Tested by observing that the `setOffline` and `setOnline` are being called now, as opposed to before.

You can yalc this branch to EchopediaWeb, go offline, click around the app for a bit, go online again, and observe in the console that your activity has been logged upon going online again.