### PR TITLE
feat: Add toggledStatuses to LegendOptions

### DIFF
--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/echo-core/src/__tests__/actions/legendOptionsStateActions.test.ts
+++ b/packages/echo-core/src/__tests__/actions/legendOptionsStateActions.test.ts
@@ -17,7 +17,7 @@ describe('legendOptionsStateActions', () => {
         it('should set legend option state and dispatch a legendTypeChanged event', () => {
             // given
             let actualEventHubPayload;
-            const legendOptionToSet = { isActive: false, selectedLegendType: 'testLegendType' };
+            const legendOptionToSet = { isActive: false, selectedLegendType: 'testLegendType', toggledStatuses: [] };
             const unsubscribe = eventHub.subscribe(EchoEvents.LegendTypeChanged, (payload) => {
                 actualEventHubPayload = payload;
             });
@@ -39,7 +39,8 @@ describe('legendOptionsStateActions', () => {
             const legendOptionToSet = { isActive: false };
             const expectedLegendOptions = {
                 ...legendOptionToSet,
-                selectedLegendType: 'Stid'
+                selectedLegendType: 'Stid',
+                toggledStatuses: []
             };
             const unsubscribe = eventHub.subscribe(EchoEvents.LegendTypeChanged, (payload) => {
                 actualEventHubPayload = payload;
@@ -62,7 +63,8 @@ describe('legendOptionsStateActions', () => {
             const result = getLegendOption();
             expect(result).toEqual({
                 isActive: true,
-                selectedLegendType: 'Stid'
+                selectedLegendType: 'Stid',
+                toggledStatuses: []
             });
         });
 
@@ -78,7 +80,8 @@ describe('legendOptionsStateActions', () => {
             // then
             expect(result).toEqual({
                 isActive: true,
-                selectedLegendType: 'aDifferentLegendType'
+                selectedLegendType: 'aDifferentLegendType',
+                toggledStatuses: []
             });
         });
     });

--- a/packages/echo-core/src/actions/index.ts
+++ b/packages/echo-core/src/actions/index.ts
@@ -1,5 +1,4 @@
 export * from './appLinks';
-export * from './legendOptions';
 export * from './module';
 export * from './moduleState';
 export * from './panels';

--- a/packages/echo-core/src/actions/index.ts
+++ b/packages/echo-core/src/actions/index.ts
@@ -1,4 +1,5 @@
 export * from './appLinks';
+export * from './legendOptions';
 export * from './module';
 export * from './moduleState';
 export * from './panels';

--- a/packages/echo-core/src/state/defaultStates.ts
+++ b/packages/echo-core/src/state/defaultStates.ts
@@ -6,7 +6,8 @@ import { PlantSettings, Settings } from '../types/settings';
 
 export const legendOptions: LegendOptions = {
     isActive: true,
-    selectedLegendType: 'Stid'
+    selectedLegendType: 'Stid',
+    toggledStatuses: []
 };
 
 const plantSettings: PlantSettings = {

--- a/packages/echo-core/src/types/legend.ts
+++ b/packages/echo-core/src/types/legend.ts
@@ -1,4 +1,5 @@
 export interface LegendOptions {
     isActive: boolean;
     selectedLegendType: string;
+    toggledStatuses: string[];
 }


### PR DESCRIPTION
### Description

To make legend items togglable I added `toggledStatuses` to the LegendOptions