### PR TITLE
fix: #48815 - Upper left search icon always visible

### DIFF
--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.0",
+    "version": "0.6.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.6.0",
+            "version": "0.6.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "^2.19.0",

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/echo-core/src/types/panel.ts
+++ b/packages/echo-core/src/types/panel.ts
@@ -18,6 +18,7 @@ export interface Panel {
     key: string;
     label: string;
     icon: Icon;
+    isToggleButtonVisible?: (() => boolean) | boolean;
     disabled?: boolean;
     customUiStates?: UiStates;
     activeCustomUiState?: string;


### PR DESCRIPTION
## Prerequisites

Please make sure you can check the following boxes:

-   [x] My code follows the code style of this project
-   [x] All new and existing tests passed
-   [x] Fix any eslint/prettier warnings/errors: npm run lint
-   [x] Remove unnecessary console.log (use logInfo logWarn if it's needed)
-   [x] Are variable and function names properly describing what it does?

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

-   [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
-   [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] I have updated the documentation accordingly
-   [ ] I have added tests to cover my changes

### Description
**Issue:**
Search panel icon is visible on the main page.
Did some digging: previously the visibility of the search icon was driven based on the visited path. Planning to make this check based on this again. Need to do some updates in our infrastructure first, though.

**Solution:**
Making possible to hide a toggle panel icon button. Would render the given panel's toggle button only if `isToggleButtonVisible` is `true`.  Can be function or a boolean primitive value.

The corePanelLeft and corePanelRight components would be updated: the toggle buttons would be rendered conditionally.

What was done:
- Extending Panel interface with `isToggleButtonVisible`

### Related PRs:
- EchoFramework: https://github.com/equinor/EchoFramework/pull/118
- EchopediaWeb: https://github.com/equinor/EchopediaWeb/pull/1067
