### PR TITLE
feat: add commPack and mcPack hooks in the registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ echoCoreDocs
 
 packages/echo-core/.yalc
 packages/echo-core/yalc.lock
+.dccache

--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.0",
+    "version": "0.6.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.6.0",
+            "version": "0.6.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "^2.19.0",

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/echo-core/src/services/hookRegistry/hookRegistry.ts
+++ b/packages/echo-core/src/services/hookRegistry/hookRegistry.ts
@@ -9,7 +9,9 @@ export enum RegisteredHookName {
     useSetActiveTagNo = 'useSetActiveTagNo',
     useContextMenuDataInfo = 'useContextMenuDataInfo',
     useTagData = 'useTagData',
-    useIsContextMenuInfoLoading = 'useIsContextMenuInfoLoading'
+    useIsContextMenuInfoLoading = 'useIsContextMenuInfoLoading',
+    useSetActiveCommPackNo = 'useSetActiveCommPackNo',
+    useSetActiveMcPackNo = 'useSetActiveMcPackNo'
 }
 
 type HookRegistryItem = {


### PR DESCRIPTION
## Prerequisites

Please make sure you can check the following boxes:

-   [ ] My code follows the code style of this project
-   [ ] All new and existing tests passed
-   [ ] Fix any eslint/prettier warnings/errors: npm run lint
-   [ ] Remove unnecessary console.log (use logInfo logWarn if it's needed)
-   [ ] Are variable and function names properly describing what it does?

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

-   [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
-   [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] I have updated the documentation accordingly
-   [ ] I have added tests to cover my changes

### Description

Adding mcPack and commPack hooks in the registry, following the way of adding new hooks to be available to for use across the modules. 

### Remarks

This is the first step. For the entire functionality, EchoFramework and EchopediaWeb needs be updated. 

### Related PRs
- https://github.com/equinor/EchoFramework/pull/119
