### PR TITLE
refactor: deprecate RegisteredHookName enum

### DIFF
--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.6.3",
+            "version": "0.6.4",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "^2.21.0",

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/echo-core/src/services/hookRegistry/hookRegistry.ts
+++ b/packages/echo-core/src/services/hookRegistry/hookRegistry.ts
@@ -2,9 +2,12 @@ import { BaseError } from '@equinor/echo-base';
 export interface EchoHookRegistry {
     registerHook: (hookRegistryItem: HookRegistryItem) => void;
     registerMultipleHooks: (hookRegistryList: HookRegistryItem[]) => void;
-    getHookByName: (hookName: RegisteredHookName) => EchoCustomHook;
+    getHookByName: (hookName: RegisteredHookName | string) => EchoCustomHook;
 }
 
+/**
+ * @deprecated This enum method should not be used. Use RegisteredHookName from EchoFramework instead.
+ */
 export enum RegisteredHookName {
     useSetActiveTagNo = 'useSetActiveTagNo',
     useContextMenuDataInfo = 'useContextMenuDataInfo',
@@ -15,7 +18,7 @@ export enum RegisteredHookName {
 }
 
 type HookRegistryItem = {
-    hookName: RegisteredHookName;
+    hookName: RegisteredHookName | string;
     hook: EchoCustomHook;
 };
 
@@ -55,7 +58,7 @@ export const echoHookRegistry = ((): EchoHookRegistry => {
          * Get's the desired hook from the registry. It doesn't call the hook, just returns with it.
          * @param hookName {RegisteredHooks}
          */
-        getHookByName: function (hookName: RegisteredHookName): EchoCustomHook {
+        getHookByName: function (hookName: RegisteredHookName | string): EchoCustomHook {
             return (
                 hookRegistry[hookName] ||
                 ((): void => {

--- a/packages/echo-core/src/services/hookRegistry/hookRegistry.ts
+++ b/packages/echo-core/src/services/hookRegistry/hookRegistry.ts
@@ -12,9 +12,7 @@ export enum RegisteredHookName {
     useSetActiveTagNo = 'useSetActiveTagNo',
     useContextMenuDataInfo = 'useContextMenuDataInfo',
     useTagData = 'useTagData',
-    useIsContextMenuInfoLoading = 'useIsContextMenuInfoLoading',
-    useSetActiveCommPackNo = 'useSetActiveCommPackNo',
-    useSetActiveMcPackNo = 'useSetActiveMcPackNo'
+    useIsContextMenuInfoLoading = 'useIsContextMenuInfoLoading'
 }
 
 type HookRegistryItem = {


### PR DESCRIPTION
### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

-   [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
-   [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] I have updated the documentation accordingly
-   [ ] I have added tests to cover my changes

### Description / Types of Changes

Deprecating RegisteredHookName enum, and setting a string type. The RegisteredHookName is moved to Framework as a duplicate, and it will be removed from Core in a future update. This is done to avoid breaking changes. 

### Remarks

Version number will be increase accordingly. 

