### PR TITLE
fix: Aligning core peer and dev deps

### DIFF
--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.5",
+    "version": "0.6.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.6.5",
+            "version": "0.6.6",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "^2.21.0",
@@ -50,7 +50,7 @@
                 "@equinor/echo-base": "^0.6.2",
                 "react": "17.0.2",
                 "react-dom": "17.0.2",
-                "react-router-dom": "6.2.1"
+                "react-router-dom": "5.3.0"
             }
         },
         ".yalc/@equinor/echo-base": {

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.5",
+    "version": "0.6.6",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
@@ -31,9 +31,9 @@
     },
     "peerDependencies": {
         "@equinor/echo-base": "^0.6.2",
-        "react": "17.0.2",
-        "react-dom": "17.0.2",
-        "react-router-dom": "6.2.1"
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "react-router-dom": "^5.3.0"
     },
     "dependencies": {
         "@azure/msal-browser": "^2.21.0",


### PR DESCRIPTION
## Prerequisites

Please make sure you can check the following boxes:

-   [x] My code follows the code style of this project
-   [x] All new and existing tests passed
-   [x] Fix any eslint/prettier warnings/errors: npm run lint
-   [x] Remove unnecessary console.log (use logInfo logWarn if it's needed)
-   [x] Are variable and function names properly describing what it does?

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

-   [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
-   [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] I have updated the documentation accordingly
-   [ ] I have added tests to cover my changes

### Description

In echo core, react router dom versions are misaligned in peer (v6.2.1) and dev dependency (v5.3.0).
Aligning them with this PR (to ^5.3.0).
Will release new version: 0.6.6. afterwards.
