### PR TITLE
fix: Stringify all localstorage data

### DIFF
--- a/packages/echo-base/package-lock.json
+++ b/packages/echo-base/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-base",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-base",
-            "version": "0.6.2",
+            "version": "0.6.3",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.1"

--- a/packages/echo-base/package.json
+++ b/packages/echo-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-base",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "module": "esm/index.js",
     "main": "lib/index.js",
     "typings": "lib/index.d.ts",

--- a/packages/echo-base/src/__tests__/utils/storage.test.ts
+++ b/packages/echo-base/src/__tests__/utils/storage.test.ts
@@ -77,7 +77,7 @@ describe('Storage', () => {
             expect(actual).toEqual(valueToSet);
         });
 
-        it('removeItem has been called with key', () => {
+        it('should call localStorage.removeItem with the given key', () => {
             storage.removeItem('foo');
 
             expect(localStorage.removeItem).toHaveBeenCalledWith('foo');

--- a/packages/echo-base/src/__tests__/utils/storage.test.ts
+++ b/packages/echo-base/src/__tests__/utils/storage.test.ts
@@ -1,20 +1,21 @@
 import { storage } from '../../utils/storage';
 
 describe('Storage', () => {
-    function mockLocalStorage<T>(mockObj: T): T {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (window as any).__defineGetter__('localStorage', () => mockObj);
-        return mockObj;
-    }
+    beforeEach(() => {
+        Object.defineProperty(window, 'localStorage', {
+            value: {
+                setItem: jest.fn(),
+                getItem: jest.fn(),
+                removeItem: jest.fn()
+            }
+        });
+    });
+
     describe('EchoLocalStorage', () => {
-        it('should set and get the correct string in localStorage', () => {
+        it('should get the correct string from localStorage', () => {
             // given
             const valueToSet = 'bar';
-            let valueInLocalStorage: string;
-            mockLocalStorage({
-                setItem: jest.fn((key: string, value: string) => (valueInLocalStorage = value)),
-                getItem: jest.fn(() => valueInLocalStorage)
-            });
+            (localStorage.getItem as jest.Mock).mockReturnValueOnce(valueToSet);
             storage.setItem<string>('foo', valueToSet);
 
             // when
@@ -24,14 +25,10 @@ describe('Storage', () => {
             expect(actual).toEqual(valueToSet);
         });
 
-        it('should set and get the correct object in localStorage', () => {
+        it('should get the correct object from localStorage', () => {
             // given
             const valueToSet = { foo: 'bar' };
-            let valueInLocalStorage: string;
-            mockLocalStorage({
-                setItem: jest.fn((key: string, value: string) => (valueInLocalStorage = value)),
-                getItem: jest.fn(() => valueInLocalStorage)
-            });
+            (localStorage.getItem as jest.Mock).mockReturnValueOnce(valueToSet);
             storage.setItem<{ foo: string }>('foo', valueToSet);
 
             // when
@@ -41,14 +38,10 @@ describe('Storage', () => {
             expect(actual).toEqual(valueToSet);
         });
 
-        it('should set and get the correct boolean in localStorage', () => {
+        it('should get the correct boolean from localStorage', () => {
             // given
             const valueToSet = true;
-            let valueInLocalStorage: string;
-            mockLocalStorage({
-                setItem: jest.fn((key: string, value: string) => (valueInLocalStorage = value)),
-                getItem: jest.fn(() => valueInLocalStorage)
-            });
+            (localStorage.getItem as jest.Mock).mockReturnValueOnce(valueToSet);
             storage.setItem<boolean>('foo', valueToSet);
 
             // when
@@ -58,14 +51,10 @@ describe('Storage', () => {
             expect(actual).toEqual(valueToSet);
         });
 
-        it('should set and get the correct number in localStorage', () => {
+        it('should get the correct number from localStorage', () => {
             // given
             const valueToSet = 1234;
-            let valueInLocalStorage: string;
-            mockLocalStorage({
-                setItem: jest.fn((key: string, value: string) => (valueInLocalStorage = value)),
-                getItem: jest.fn(() => valueInLocalStorage)
-            });
+            (localStorage.getItem as jest.Mock).mockReturnValueOnce(valueToSet);
             storage.setItem<number>('foo', valueToSet);
 
             // when
@@ -75,14 +64,10 @@ describe('Storage', () => {
             expect(actual).toEqual(valueToSet);
         });
 
-        it('should set and get the correct date in localStorage', () => {
+        it('should get the correct date from localStorage', () => {
             // given
             const valueToSet = new Date();
-            let valueInLocalStorage: string;
-            mockLocalStorage({
-                setItem: jest.fn((key: string, value: string) => (valueInLocalStorage = value)),
-                getItem: jest.fn(() => valueInLocalStorage)
-            });
+            (localStorage.getItem as jest.Mock).mockReturnValueOnce(valueToSet);
             storage.setItem<Date>('foo', valueToSet);
 
             // when
@@ -93,13 +78,9 @@ describe('Storage', () => {
         });
 
         it('removeItem has been called with key', () => {
-            const localStorage = mockLocalStorage({
-                removeItem: jest.fn()
-            });
             storage.removeItem('foo');
 
-            expect(localStorage.removeItem).toBeCalledWith('foo');
-            expect(localStorage.removeItem).toHaveBeenCalledTimes(1);
+            expect(localStorage.removeItem).toHaveBeenCalledWith('foo');
         });
     });
 });

--- a/packages/echo-base/src/__tests__/utils/storage.test.ts
+++ b/packages/echo-base/src/__tests__/utils/storage.test.ts
@@ -15,7 +15,11 @@ describe('Storage', () => {
         it('should get the correct string from localStorage', () => {
             // given
             const valueToSet = 'bar';
-            (localStorage.getItem as jest.Mock).mockReturnValueOnce(valueToSet);
+            let valueInLocalStorage: string;
+            (localStorage.getItem as jest.Mock).mockImplementationOnce(() => valueInLocalStorage);
+            (localStorage.setItem as jest.Mock).mockImplementationOnce(
+                (key: string, value: string) => (valueInLocalStorage = value)
+            );
             storage.setItem<string>('foo', valueToSet);
 
             // when
@@ -27,8 +31,12 @@ describe('Storage', () => {
 
         it('should get the correct object from localStorage', () => {
             // given
-            const valueToSet = { foo: 'bar' };
-            (localStorage.getItem as jest.Mock).mockReturnValueOnce(valueToSet);
+            const valueToSet = { foo: 'bar', aDate: new Date() };
+            let valueInLocalStorage: string;
+            (localStorage.getItem as jest.Mock).mockImplementationOnce(() => valueInLocalStorage);
+            (localStorage.setItem as jest.Mock).mockImplementationOnce(
+                (key: string, value: string) => (valueInLocalStorage = value)
+            );
             storage.setItem<{ foo: string }>('foo', valueToSet);
 
             // when
@@ -41,7 +49,11 @@ describe('Storage', () => {
         it('should get the correct boolean from localStorage', () => {
             // given
             const valueToSet = true;
-            (localStorage.getItem as jest.Mock).mockReturnValueOnce(valueToSet);
+            let valueInLocalStorage: string;
+            (localStorage.getItem as jest.Mock).mockImplementationOnce(() => valueInLocalStorage);
+            (localStorage.setItem as jest.Mock).mockImplementationOnce(
+                (key: string, value: string) => (valueInLocalStorage = value)
+            );
             storage.setItem<boolean>('foo', valueToSet);
 
             // when
@@ -54,7 +66,11 @@ describe('Storage', () => {
         it('should get the correct number from localStorage', () => {
             // given
             const valueToSet = 1234;
-            (localStorage.getItem as jest.Mock).mockReturnValueOnce(valueToSet);
+            let valueInLocalStorage: string;
+            (localStorage.getItem as jest.Mock).mockImplementationOnce(() => valueInLocalStorage);
+            (localStorage.setItem as jest.Mock).mockImplementationOnce(
+                (key: string, value: string) => (valueInLocalStorage = value)
+            );
             storage.setItem<number>('foo', valueToSet);
 
             // when
@@ -67,7 +83,11 @@ describe('Storage', () => {
         it('should get the correct date from localStorage', () => {
             // given
             const valueToSet = new Date();
-            (localStorage.getItem as jest.Mock).mockReturnValueOnce(valueToSet);
+            let valueInLocalStorage: string;
+            (localStorage.getItem as jest.Mock).mockImplementationOnce(() => valueInLocalStorage);
+            (localStorage.setItem as jest.Mock).mockImplementationOnce(
+                (key: string, value: string) => (valueInLocalStorage = value)
+            );
             storage.setItem<Date>('foo', valueToSet);
 
             // when

--- a/packages/echo-base/src/__tests__/utils/storage.test.ts
+++ b/packages/echo-base/src/__tests__/utils/storage.test.ts
@@ -53,7 +53,7 @@ describe('Storage', () => {
             });
             storage.setItem<string>('foo', 'bar');
 
-            expect(localStorage.setItem).toBeCalledWith('foo', 'bar');
+            expect(localStorage.setItem).toBeCalledWith('foo', JSON.stringify('bar'));
             expect(localStorage.setItem).toHaveBeenCalledTimes(1);
         });
 

--- a/packages/echo-base/src/__tests__/utils/storage.test.ts
+++ b/packages/echo-base/src/__tests__/utils/storage.test.ts
@@ -11,15 +11,19 @@ describe('Storage', () => {
         });
     });
 
+    function mockLocalStorage() {
+        let valueInLocalStorage: string;
+        (localStorage.getItem as jest.Mock).mockImplementationOnce(() => valueInLocalStorage);
+        (localStorage.setItem as jest.Mock).mockImplementationOnce(
+            (key: string, value: string) => (valueInLocalStorage = value)
+        );
+    }
+
     describe('EchoLocalStorage', () => {
         it('should get the correct string from localStorage', () => {
             // given
             const valueToSet = 'bar';
-            let valueInLocalStorage: string;
-            (localStorage.getItem as jest.Mock).mockImplementationOnce(() => valueInLocalStorage);
-            (localStorage.setItem as jest.Mock).mockImplementationOnce(
-                (key: string, value: string) => (valueInLocalStorage = value)
-            );
+            mockLocalStorage();
             storage.setItem<string>('foo', valueToSet);
 
             // when
@@ -32,11 +36,7 @@ describe('Storage', () => {
         it('should get the correct object from localStorage', () => {
             // given
             const valueToSet = { foo: 'bar', aDate: new Date() };
-            let valueInLocalStorage: string;
-            (localStorage.getItem as jest.Mock).mockImplementationOnce(() => valueInLocalStorage);
-            (localStorage.setItem as jest.Mock).mockImplementationOnce(
-                (key: string, value: string) => (valueInLocalStorage = value)
-            );
+            mockLocalStorage();
             storage.setItem<{ foo: string }>('foo', valueToSet);
 
             // when
@@ -49,11 +49,7 @@ describe('Storage', () => {
         it('should get the correct boolean from localStorage', () => {
             // given
             const valueToSet = true;
-            let valueInLocalStorage: string;
-            (localStorage.getItem as jest.Mock).mockImplementationOnce(() => valueInLocalStorage);
-            (localStorage.setItem as jest.Mock).mockImplementationOnce(
-                (key: string, value: string) => (valueInLocalStorage = value)
-            );
+            mockLocalStorage();
             storage.setItem<boolean>('foo', valueToSet);
 
             // when
@@ -66,11 +62,7 @@ describe('Storage', () => {
         it('should get the correct number from localStorage', () => {
             // given
             const valueToSet = 1234;
-            let valueInLocalStorage: string;
-            (localStorage.getItem as jest.Mock).mockImplementationOnce(() => valueInLocalStorage);
-            (localStorage.setItem as jest.Mock).mockImplementationOnce(
-                (key: string, value: string) => (valueInLocalStorage = value)
-            );
+            mockLocalStorage();
             storage.setItem<number>('foo', valueToSet);
 
             // when
@@ -83,11 +75,7 @@ describe('Storage', () => {
         it('should get the correct date from localStorage', () => {
             // given
             const valueToSet = new Date();
-            let valueInLocalStorage: string;
-            (localStorage.getItem as jest.Mock).mockImplementationOnce(() => valueInLocalStorage);
-            (localStorage.setItem as jest.Mock).mockImplementationOnce(
-                (key: string, value: string) => (valueInLocalStorage = value)
-            );
+            mockLocalStorage();
             storage.setItem<Date>('foo', valueToSet);
 
             // when

--- a/packages/echo-base/src/__tests__/utils/storage.test.ts
+++ b/packages/echo-base/src/__tests__/utils/storage.test.ts
@@ -7,34 +7,89 @@ describe('Storage', () => {
         return mockObj;
     }
     describe('EchoLocalStorage', () => {
-        it('getItem string from local storage', () => {
-            const localStorage = mockLocalStorage({
-                getItem: jest.fn(() => 'bar')
+        it('should set and get the correct string in localStorage', () => {
+            // given
+            const valueToSet = 'bar';
+            let valueInLocalStorage: string;
+            mockLocalStorage({
+                setItem: jest.fn((key: string, value: string) => (valueInLocalStorage = value)),
+                getItem: jest.fn(() => valueInLocalStorage)
             });
-            const result = storage.getItem<string>('foo');
-            expect(result).toEqual('bar');
-            expect(localStorage.getItem).toHaveBeenCalledTimes(1);
+            storage.setItem<string>('foo', valueToSet);
+
+            // when
+            const actual = storage.getItem<string>('foo');
+
+            // then
+            expect(actual).toEqual(valueToSet);
         });
 
-        it('getItem from local storage', () => {
-            const item = { item: 'bar' };
-            const localStorage = mockLocalStorage({
-                getItem: jest.fn(() => JSON.stringify(item))
+        it('should set and get the correct object in localStorage', () => {
+            // given
+            const valueToSet = { foo: 'bar' };
+            let valueInLocalStorage: string;
+            mockLocalStorage({
+                setItem: jest.fn((key: string, value: string) => (valueInLocalStorage = value)),
+                getItem: jest.fn(() => valueInLocalStorage)
             });
-            const result = storage.getItem<{ item: string }>('foo');
+            storage.setItem<{ foo: string }>('foo', valueToSet);
 
-            expect(result).toEqual(item);
-            expect(localStorage.getItem).toHaveBeenCalledTimes(1);
+            // when
+            const actual = storage.getItem<{ foo: string }>('foo');
+
+            // then
+            expect(actual).toEqual(valueToSet);
         });
 
-        it('getItem from local storage as undefined', () => {
-            const localStorage = mockLocalStorage({
-                getItem: jest.fn(() => undefined)
+        it('should set and get the correct boolean in localStorage', () => {
+            // given
+            const valueToSet = true;
+            let valueInLocalStorage: string;
+            mockLocalStorage({
+                setItem: jest.fn((key: string, value: string) => (valueInLocalStorage = value)),
+                getItem: jest.fn(() => valueInLocalStorage)
             });
-            const result = storage.getItem('foo');
+            storage.setItem<boolean>('foo', valueToSet);
 
-            expect(undefined).toEqual(result);
-            expect(localStorage.getItem).toHaveBeenCalledTimes(1);
+            // when
+            const actual = storage.getItem<boolean>('foo');
+
+            // then
+            expect(actual).toEqual(valueToSet);
+        });
+
+        it('should set and get the correct number in localStorage', () => {
+            // given
+            const valueToSet = 1234;
+            let valueInLocalStorage: string;
+            mockLocalStorage({
+                setItem: jest.fn((key: string, value: string) => (valueInLocalStorage = value)),
+                getItem: jest.fn(() => valueInLocalStorage)
+            });
+            storage.setItem<number>('foo', valueToSet);
+
+            // when
+            const actual = storage.getItem<number>('foo');
+
+            // then
+            expect(actual).toEqual(valueToSet);
+        });
+
+        it('should set and get the correct date in localStorage', () => {
+            // given
+            const valueToSet = new Date();
+            let valueInLocalStorage: string;
+            mockLocalStorage({
+                setItem: jest.fn((key: string, value: string) => (valueInLocalStorage = value)),
+                getItem: jest.fn(() => valueInLocalStorage)
+            });
+            storage.setItem<Date>('foo', valueToSet);
+
+            // when
+            const actual = storage.getItem<Date>('foo');
+
+            // then
+            expect(actual).toEqual(valueToSet);
         });
 
         it('removeItem has been called with key', () => {
@@ -45,27 +100,6 @@ describe('Storage', () => {
 
             expect(localStorage.removeItem).toBeCalledWith('foo');
             expect(localStorage.removeItem).toHaveBeenCalledTimes(1);
-        });
-
-        it('setItem has been called with key and string', () => {
-            const localStorage = mockLocalStorage({
-                setItem: jest.fn()
-            });
-            storage.setItem<string>('foo', 'bar');
-
-            expect(localStorage.setItem).toBeCalledWith('foo', JSON.stringify('bar'));
-            expect(localStorage.setItem).toHaveBeenCalledTimes(1);
-        });
-
-        it('setItem has been called with key and data', () => {
-            const data = { item: 'bar' };
-            const localStorage = mockLocalStorage({
-                setItem: jest.fn()
-            });
-            storage.setItem('foo', data);
-
-            expect(localStorage.setItem).toBeCalledWith('foo', JSON.stringify(data));
-            expect(localStorage.setItem).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/echo-base/src/utils/storage.ts
+++ b/packages/echo-base/src/utils/storage.ts
@@ -3,11 +3,7 @@ import { parseJsonWithDate } from './jsonParseUtils';
 
 export const storage: EchoLocalStorage = {
     setItem: <T>(key: string, data: T) => {
-        if (typeof data === 'string') {
-            localStorage.setItem(key, data);
-        } else {
-            localStorage.setItem(key, JSON.stringify(data));
-        }
+        localStorage.setItem(key, JSON.stringify(data));
     },
 
     getItem: <T>(key: string) => {


### PR DESCRIPTION
### Description

We were checking if data was a string before stringifying it when setting it in localstorage. We should stringify the data, even if it is a string to ensure correct types when parsing it. 
Removed this check, and we are now stringifying everything before adding it to localstorage.