### PR TITLE
fix(#65850): Handle rejected echo modules

### DIFF
--- a/packages/echo-base/package-lock.json
+++ b/packages/echo-base/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-base",
-    "version": "0.6.4",
+    "version": "0.6.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-base",
-            "version": "0.6.4",
+            "version": "0.6.8",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.1"

--- a/packages/echo-base/package.json
+++ b/packages/echo-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-base",
-    "version": "0.6.4",
+    "version": "0.6.8",
     "module": "esm/index.js",
     "main": "lib/index.js",
     "typings": "lib/index.d.ts",

--- a/packages/echo-base/src/module/dependency.ts
+++ b/packages/echo-base/src/module/dependency.ts
@@ -85,7 +85,9 @@ export async function appendScriptTagToDom(
         window[depName] = getLocalRequire(dependencies);
 
         script.onload = (): void => resolve(verifyAppWithModule(name, script.module));
-        script.onerror = (): void => reject('could not load');
+        script.onerror = (): void => {
+            reject(`Could not load module ${name}`);
+        };
 
         document.head.appendChild(script);
     });
@@ -130,5 +132,6 @@ export async function includeModuleWithDependencies(
     dependencies?: AvailableDependencies,
     crossOrigin?: string
 ): Promise<ModuleData> {
-    return await appendScriptTagToDom(name, link, requireRef, dependencies, crossOrigin, integrity);
+    appendScriptTagToDom(name, link, requireRef, dependencies, crossOrigin, integrity).catch(() => console.error);
+    return appendScriptTagToDom(name, link, requireRef, dependencies, crossOrigin, integrity);
 }

--- a/packages/echo-base/src/module/dependency.ts
+++ b/packages/echo-base/src/module/dependency.ts
@@ -130,6 +130,5 @@ export async function includeModuleWithDependencies(
     dependencies?: AvailableDependencies,
     crossOrigin?: string
 ): Promise<ModuleData> {
-    appendScriptTagToDom(name, link, requireRef, dependencies, crossOrigin, integrity).catch(() => console.error);
     return appendScriptTagToDom(name, link, requireRef, dependencies, crossOrigin, integrity);
 }

--- a/packages/echo-base/src/module/dependency.ts
+++ b/packages/echo-base/src/module/dependency.ts
@@ -85,9 +85,7 @@ export async function appendScriptTagToDom(
         window[depName] = getLocalRequire(dependencies);
 
         script.onload = (): void => resolve(verifyAppWithModule(name, script.module));
-        script.onerror = (): void => {
-            reject(`Could not load module ${name}`);
-        };
+        script.onerror = (): void => reject(`Could not load module ${name}`);
 
         document.head.appendChild(script);
     });


### PR DESCRIPTION
### Description

When loading the modules, we were using `Promise.all` to resolve the module promises. This meant that if one module was rejected due to an error, all of them would be rejected. 

To properly handle rejected modules, we switch to using `Promise.allSettled` so we can filter out the resolved modules.

### Remarks

A module might be rejected due to, e.g., a fileUri which is not approved by our CORS policy. This is a safe guard so the rejected module does not reject the rest of the app. The rejected module will still show up as a blank page, but the other modules will not be affected.

### How to test

The test branch should be running with this version of base. The camera module will be blank, and there will be an error in the console saying that the module could not load. The rest of the app should work fine.