### PR TITLE
fix(#73946): Change login request scope to .default

### DIFF
--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.14",
+    "version": "0.6.16",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.6.14",
+            "version": "0.6.16",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "^2.25.0",

--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.12",
+    "version": "0.6.14",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.6.12",
+            "version": "0.6.14",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "^2.25.0",

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.12",
+    "version": "0.6.15",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
@@ -48,7 +48,7 @@
         "@babel/preset-typescript": "^7.17.12",
         "@equinor/echo-base": "^0.6.8",
         "@microsoft/microsoft-graph-types": "^2.20.0",
-        "@microsoft/microsoft-graph-types-beta": "^0.29.0-preview",        
+        "@microsoft/microsoft-graph-types-beta": "^0.29.0-preview",
         "@rollup/plugin-babel": "^5.3.1",
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-node-resolve": "^13.3.0",

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.15",
+    "version": "0.6.16",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/echo-core/src/services/authentication/authProviderConfig.ts
+++ b/packages/echo-core/src/services/authentication/authProviderConfig.ts
@@ -17,7 +17,7 @@ export const logoutRequest = (user: AccountInfo): EndSessionRequest => {
  * Based on the @azure/msal-browser package
  */
 export const defaultLoginRequest: RedirectRequest = {
-    scopes: ['openid', 'profile', 'User.Read', 'offline_access'],
+    scopes: ['.default'],
     prompt: 'select_account'
 };
 
@@ -30,6 +30,6 @@ export const loginSilentlyRequest = (user: AccountInfo): SilentRequest => {
     return {
         account: user,
         forceRefresh: false,
-        scopes: ['openid', 'profile', 'User.Read', 'offline_access']
+        scopes: ['.default']
     };
 };


### PR DESCRIPTION
### Description

When adding new SWAs in Azure, we need to request admin consent the first time the app is opened. Usually this request should include all the API permissions we have added to the app. In our case, it only included Microsoft Graph in the request, and not the echopedia APIs.

Changing the request scope to `.default` includes the proper API permissions in the request, meaning we don't have to email equinor azure admins to manually grant consent anymore. 

After the change you can see the Echopedia APIs are included in the request (this is from the XLD app):
![MicrosoftTeams-image](https://user-images.githubusercontent.com/74668394/174766045-fba0e278-e59c-4ac3-8fb7-c4caa5287c2f.png)


