### PR TITLE
fix: 69299 Added ErrorUtils.is.error etc

### DIFF
--- a/packages/echo-base/package-lock.json
+++ b/packages/echo-base/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-base",
-    "version": "0.6.8",
+    "version": "0.6.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-base",
-            "version": "0.6.8",
+            "version": "0.6.9",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.4.0"

--- a/packages/echo-base/package.json
+++ b/packages/echo-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-base",
-    "version": "0.6.8",
+    "version": "0.6.9",
     "module": "esm/index.js",
     "main": "lib/index.js",
     "typings": "lib/index.d.ts",

--- a/packages/echo-base/src/__tests__/errors/NetworkError.test.ts
+++ b/packages/echo-base/src/__tests__/errors/NetworkError.test.ts
@@ -29,6 +29,7 @@ describe('NetworkError', () => {
 
     it('check NetworkError properties', () => {
         const properties = {
+            hasBeenLogged: false,
             httpStatusCode,
             url,
             message: 'Network Error Testing',
@@ -67,6 +68,7 @@ describe('NetworkError & subclasses', () => {
     const networkArgs = { message, httpStatusCode, url, exception };
     const expectedProperties = {
         message,
+        hasBeenLogged: false,
         httpStatusCode,
         url,
         innerError: exception,

--- a/packages/echo-base/src/errors/BaseError.test.ts
+++ b/packages/echo-base/src/errors/BaseError.test.ts
@@ -70,6 +70,20 @@ describe('getAllProperties', () => {
     });
 });
 
+describe('getAllProperties.ignore', () => {
+    it('ignoreEquals should ignore all properties specified, including nested object', () => {
+        const input = { abc: 'a', bcd: 1, cde: { nestedProp: 'prop1', abc: '123' } };
+        const actualError = getAllProperties(input, { ignoreEquals: ['abc', 'bcd'] });
+        expect(actualError).toStrictEqual({ cde: { nestedProp: 'prop1' } });
+    });
+
+    it('ignoreIncludes should ignore all properties specified, including nested object', () => {
+        const input = { abc: 'a', bcd: 1, ddd: { nestedProp: 'prop1', bc: '123' } };
+        const actualError = getAllProperties(input, { ignoreIncludes: ['a', 'c'] });
+        expect(actualError).toStrictEqual({ ddd: { nestedProp: 'prop1' } });
+    });
+});
+
 describe('findPropertyByName', () => {
     const message = 'This is a custom error message for testing';
 

--- a/packages/echo-base/src/errors/BaseError.test.ts
+++ b/packages/echo-base/src/errors/BaseError.test.ts
@@ -82,6 +82,12 @@ describe('getAllProperties.ignore', () => {
         const actualError = getAllProperties(input, { ignoreIncludes: ['a', 'c'] });
         expect(actualError).toStrictEqual({ ddd: { nestedProp: 'prop1' } });
     });
+
+    it('ignore should handle both equals and includes at the same time, and it should be case insensitive', () => {
+        const input = { stack: 'a', bcd: 1, ddd: { innerStack: 'prop1', Y: '1', N: '0' } };
+        const actualError = getAllProperties(input, { ignoreIncludes: ['stack'], ignoreEquals: ['y'] });
+        expect(actualError).toStrictEqual({ bcd: 1, ddd: { N: '0' } });
+    });
 });
 
 describe('findPropertyByName', () => {

--- a/packages/echo-base/src/errors/BaseError.ts
+++ b/packages/echo-base/src/errors/BaseError.ts
@@ -149,7 +149,7 @@ export function getAllProperties(
     names.forEach((name) => {
         const value = object[name];
         const valueType = typeof value;
-        if (valueType === 'function' || shouldIgnore(name, args)) {
+        if (valueType === 'function' || isPropertyIgnored(name, args)) {
             //ignore
         } else if (typeof value === 'object') {
             rec[name] = getAllProperties(value, args);
@@ -160,18 +160,18 @@ export function getAllProperties(
     return rec;
 }
 
-function shouldIgnore(name: string, args?: { ignoreEquals?: string[]; ignoreIncludes?: string[] }) {
+function isPropertyIgnored(name: string, args?: { ignoreEquals?: string[]; ignoreIncludes?: string[] }) {
     if (!args) {
         return false;
     }
 
     name = name.toLocaleLowerCase();
 
-    if (args.ignoreEquals && args.ignoreEquals.some((item) => name === item.toLocaleLowerCase())) {
+    if (args.ignoreIncludes && args.ignoreIncludes.some((item) => name.includes(item.toLocaleLowerCase()))) {
         return true;
     }
 
-    if (args.ignoreIncludes && args.ignoreIncludes.some((item) => name.includes(item.toLocaleLowerCase()))) {
+    if (args.ignoreEquals && args.ignoreEquals.some((item) => name === item.toLocaleLowerCase())) {
         return true;
     }
 }

--- a/packages/echo-base/src/errors/BaseError.ts
+++ b/packages/echo-base/src/errors/BaseError.ts
@@ -123,10 +123,13 @@ export function findPropertyByName(
  * Supports custom Error which has public or private fields. Will ignore any functions on the Error object.
  * It does not support cycling references (A -> B -> A).
  * @param objectWithProperties an object containing properties
+ * @param args.ignoreEquals ignore/omit any property that equals this (case insensitive)
+ * @param args.ignoreIncludes ignore/omit any property that includes this (case insensitive)
  * @returns a record containing all properties of the object
  */
 export function getAllProperties(
-    objectWithProperties: Record<string, unknown> | Error | undefined
+    objectWithProperties: Record<string, unknown> | object | undefined,
+    args?: { ignoreEquals?: string[]; ignoreIncludes?: string[] }
 ): Record<string, unknown> {
     if (!objectWithProperties) {
         return {};
@@ -148,11 +151,27 @@ export function getAllProperties(
         const valueType = typeof value;
         if (valueType === 'function') {
             //ignore
-        } else if (value instanceof Error) {
-            rec[name] = getAllProperties(value);
-        } else {
+        } else if (typeof value === 'object' && !shouldIgnore(name, args)) {
+            rec[name] = getAllProperties(value, args);
+        } else if (!shouldIgnore(name, args)) {
             rec[name] = value;
         }
     });
     return rec;
+}
+
+function shouldIgnore(name: string, args?: { ignoreEquals?: string[]; ignoreIncludes?: string[] }) {
+    if (!args) {
+        return false;
+    }
+
+    name = name.toLocaleLowerCase();
+
+    if (args.ignoreEquals && args.ignoreEquals.some((item) => name === item.toLocaleLowerCase())) {
+        return true;
+    }
+
+    if (args.ignoreIncludes && args.ignoreIncludes.some((item) => name.includes(item.toLocaleLowerCase()))) {
+        return true;
+    }
 }

--- a/packages/echo-base/src/errors/BaseError.ts
+++ b/packages/echo-base/src/errors/BaseError.ts
@@ -149,11 +149,11 @@ export function getAllProperties(
     names.forEach((name) => {
         const value = object[name];
         const valueType = typeof value;
-        if (valueType === 'function') {
+        if (valueType === 'function' || shouldIgnore(name, args)) {
             //ignore
-        } else if (typeof value === 'object' && !shouldIgnore(name, args)) {
+        } else if (typeof value === 'object') {
             rec[name] = getAllProperties(value, args);
-        } else if (!shouldIgnore(name, args)) {
+        } else {
             rec[name] = value;
         }
     });

--- a/packages/echo-base/src/errors/errorUtils.test.ts
+++ b/packages/echo-base/src/errors/errorUtils.test.ts
@@ -1,0 +1,62 @@
+import { BaseError } from './BaseError';
+import { errorUtils } from './errorUtils';
+import { BackendError, ForbiddenError, NetworkError, NotFoundError, UnauthorizedError } from './NetworkError';
+
+describe('errorUtils.is', () => {
+    it('is.error', () => {
+        expect(errorUtils.is.error('invalid Error' as unknown as Error)).toBe(false);
+        expect(errorUtils.is.error(new Error())).toBe(true);
+        expect(errorUtils.is.error(new NetworkError({ httpStatusCode: 400, url: 'test' }))).toBe(true);
+    });
+
+    it('is.baseError', () => {
+        expect(errorUtils.is.baseError(new Error())).toBe(false);
+        expect(errorUtils.is.baseError(new BaseError({ name: '', message: '' }))).toBe(true);
+    });
+
+    it('is.networkError', () => {
+        expect(errorUtils.is.networkError(new Error())).toBe(false);
+        expect(errorUtils.is.networkError(new NetworkError({ httpStatusCode: 0, url: 'test' }))).toBe(true);
+        expect(errorUtils.is.networkError(new NetworkError({ httpStatusCode: 400, url: 'test' }))).toBe(true);
+    });
+
+    it('is.backendError', () => {
+        expect(errorUtils.is.backendError(new Error())).toBe(false);
+        expect(errorUtils.is.backendError(new NetworkError({ httpStatusCode: 0, url: 'test' }))).toBe(false);
+        expect(errorUtils.is.backendError(new BackendError({ httpStatusCode: 400, url: 'test' }))).toBe(true);
+    });
+
+    it('is.notFoundError', () => {
+        expect(errorUtils.is.notFoundError(new Error())).toBe(false);
+        expect(errorUtils.is.notFoundError(new NetworkError({ httpStatusCode: 400, url: 'test' }))).toBe(false);
+        expect(errorUtils.is.notFoundError(new NetworkError({ httpStatusCode: 404, url: 'test' }))).toBe(true);
+        expect(errorUtils.is.notFoundError(new NotFoundError({ httpStatusCode: 404, url: 'test' }))).toBe(true);
+        expect(
+            errorUtils.is.notFoundError(new NotFoundError({ httpStatusCode: 500, url: 'test', name: 'NotFoundError' }))
+        ).toBe(true);
+    });
+
+    it('is.forbiddenError', () => {
+        expect(errorUtils.is.forbiddenError(new Error())).toBe(false);
+        expect(errorUtils.is.forbiddenError(new NetworkError({ httpStatusCode: 400, url: 'test' }))).toBe(false);
+        expect(errorUtils.is.forbiddenError(new UnauthorizedError({ httpStatusCode: 401, url: 'test' }))).toBe(false);
+        expect(errorUtils.is.forbiddenError(new ForbiddenError({ httpStatusCode: 403, url: 'test' }))).toBe(true);
+        expect(
+            errorUtils.is.forbiddenError(
+                new UnauthorizedError({ httpStatusCode: 500, url: 'test', name: 'ForbiddenError' })
+            )
+        ).toBe(true);
+    });
+
+    it('is.forbiddenError', () => {
+        expect(errorUtils.is.unauthorizedError(new Error())).toBe(false);
+        expect(errorUtils.is.unauthorizedError(new NetworkError({ httpStatusCode: 400, url: 'test' }))).toBe(false);
+        expect(errorUtils.is.unauthorizedError(new ForbiddenError({ httpStatusCode: 403, url: 'test' }))).toBe(false);
+        expect(errorUtils.is.unauthorizedError(new UnauthorizedError({ httpStatusCode: 401, url: 'test' }))).toBe(true);
+        expect(
+            errorUtils.is.unauthorizedError(
+                new ForbiddenError({ httpStatusCode: 500, url: 'test', name: 'UnauthorizedError' })
+            )
+        ).toBe(true);
+    });
+});

--- a/packages/echo-base/src/errors/errorUtils.ts
+++ b/packages/echo-base/src/errors/errorUtils.ts
@@ -33,14 +33,12 @@ function isBaseError(error: Error): error is BaseError {
 
 function isNetworkError(error: Error): error is NetworkError {
     const httpStatusCode = findPropertyByName(error, 'httpStatusCode');
-    //httpStatusCode 0 means there was network problems / missing connection
-    return httpStatusCode >= 0 || error.name === NetworkError.name;
+    return isNetworkErrorByHttpCode(httpStatusCode) || error.name === NetworkError.name;
 }
 
 function isBackendError(error: Error): error is BackendError {
     const httpStatusCode = findPropertyByName(error, 'httpStatusCode');
-    //httpStatusCode > 0 means we got a response from the server
-    return httpStatusCode > 0 || error.name === BackendError.name;
+    return isServerResponseByHttpCode(httpStatusCode) || error.name === BackendError.name;
 }
 
 function isForbiddenError(error: Error): error is ForbiddenError {
@@ -56,4 +54,12 @@ function isUnauthorizedError(error: Error): error is UnauthorizedError {
 function isNotFoundError(error: Error): error is NotFoundError {
     const httpStatusCode = findPropertyByName(error, 'httpStatusCode');
     return httpStatusCode === 404 || error.name === NotFoundError.name;
+}
+
+function isServerResponseByHttpCode(httpStatusCode: number | unknown): boolean {
+    return httpStatusCode > 0;
+}
+
+function isNetworkErrorByHttpCode(httpStatusCode: number | unknown): boolean {
+    return httpStatusCode >= 0;
 }

--- a/packages/echo-base/src/errors/errorUtils.ts
+++ b/packages/echo-base/src/errors/errorUtils.ts
@@ -1,0 +1,59 @@
+import { BaseError, findPropertyByName, getAllProperties } from './BaseError';
+import { BackendError, ForbiddenError, NetworkError, NotFoundError, UnauthorizedError } from './NetworkError';
+import { toError } from './toError';
+
+const is = {
+    error: isError,
+    baseError: isBaseError,
+    networkError: isNetworkError,
+    backendError: isBackendError,
+    notFoundError: isNotFoundError,
+    forbiddenError: isForbiddenError,
+    unauthorizedError: isUnauthorizedError
+};
+
+export const errorUtils = {
+    toError,
+    is,
+    findPropertyByName,
+    getAllProperties
+};
+
+// instanceOf does not work if the error was thrown in another module, instead we compare by known properties such as httpStatusCode or errorClass.name
+// also see: https://medium.com/@samjwright/why-is-instanceof-my-object-returning-false-in-typescript-fec74df5c2a8
+
+function isError(err: Error): err is Error {
+    return typeof err === 'object' && !!err && 'message' in err && 'name' in err;
+}
+
+function isBaseError(error: Error): error is BaseError {
+    const hasBeenLoggedValue = findPropertyByName(error, 'hasBeenLogged');
+    return isError(error) && hasBeenLoggedValue !== undefined;
+}
+
+function isNetworkError(error: Error): error is NetworkError {
+    const httpStatusCode = findPropertyByName(error, 'httpStatusCode');
+    //httpStatusCode 0 means there was network problems / missing connection
+    return httpStatusCode >= 0 || error.name === NetworkError.name;
+}
+
+function isBackendError(error: Error): error is BackendError {
+    const httpStatusCode = findPropertyByName(error, 'httpStatusCode');
+    //httpStatusCode > 0 means we got a response from the server
+    return httpStatusCode > 0 || error.name === BackendError.name;
+}
+
+function isForbiddenError(error: Error): error is ForbiddenError {
+    const httpStatusCode = findPropertyByName(error, 'httpStatusCode');
+    return httpStatusCode === 403 || error.name === ForbiddenError.name;
+}
+
+function isUnauthorizedError(error: Error): error is UnauthorizedError {
+    const httpStatusCode = findPropertyByName(error, 'httpStatusCode');
+    return httpStatusCode === 401 || error.name === UnauthorizedError.name;
+}
+
+function isNotFoundError(error: Error): error is NotFoundError {
+    const httpStatusCode = findPropertyByName(error, 'httpStatusCode');
+    return httpStatusCode === 404 || error.name === NotFoundError.name;
+}


### PR DESCRIPTION
Please also review this commit which I managed to push to the main branch:
https://github.com/equinor/EchoCore/commit/687c63e9af6432afc482f340e590438463181382
We didn't return the value if it was set to false or empty string.

Added errorUtils helper function for checking if it's an error, baseError, etc. Since error instanceof NetworkError doesn't work across modules as described here: https://medium.com/@samjwright/why-is-instanceof-my-object-returning-false-in-typescript-fec74df5c2a8

Tested with unit tests
