### PR TITLE
fix: 69299 Release v0.6.10, Export errorUtils & updated changelog

### DIFF
--- a/packages/echo-base/package-lock.json
+++ b/packages/echo-base/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-base",
-    "version": "0.6.9",
+    "version": "0.6.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-base",
-            "version": "0.6.9",
+            "version": "0.6.10",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.4.0"

--- a/packages/echo-base/package.json
+++ b/packages/echo-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-base",
-    "version": "0.6.9",
+    "version": "0.6.10",
     "module": "esm/index.js",
     "main": "lib/index.js",
     "typings": "lib/index.d.ts",

--- a/packages/echo-base/src/errors/BaseError.ts
+++ b/packages/echo-base/src/errors/BaseError.ts
@@ -93,7 +93,7 @@ export class BaseError extends Error {
  * @returns the value of the property found or undefined
  */
 export function findPropertyByName(
-    object: Record<string, unknown> | Error,
+    object: Record<string, unknown> | object,
     propertyName: string,
     deepSearch = true
 ): unknown | undefined {

--- a/packages/echo-base/src/errors/index.ts
+++ b/packages/echo-base/src/errors/index.ts
@@ -1,5 +1,6 @@
 export * from './ArgumentError';
 export * from './BaseError';
 export * from './errorHandlers';
+export { errorUtils } from './errorUtils';
 export * from './NetworkError';
 export * from './toError';

--- a/packages/echo-core/CHANGELOG.md
+++ b/packages/echo-core/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## v0.6.10
+
+### Added
+
+- Added echoUtils which contains helper functions:
+
+```TS
+const errorUtils: {
+    toError: (error: unknown) => BaseError | Error;
+    is: {
+        error: (err: Error) => err is Error;
+        baseError: (error: Error) => error is BaseError;
+        networkError: (error: Error) => error is NetworkError;
+        backendError: (error: Error) => error is BackendError;
+        notFoundError: (error: Error) => error is NotFoundError;
+        forbiddenError: (error: Error) => error is ForbiddenError;
+        unauthorizedError: (error: Error) => error is UnauthorizedError;
+    };
+    findPropertyByName: (object: Error | Record<string, unknown>, propertyName: string, deepSearch?: boolean) => unknown;
+    getAllProperties: (objectWithProperties: object | Record<string, unknown>, args?: { ignoreEquals?: string[]; ignoreIncludes?: string[] 
+    }) => Record<string, unknown>;
+}
+```
+
+## v0.6.9
+
+### Fix
+
+- findPropertyByName: will now also find negative values as empty string and boolean which is set to false.
+- findPropertyByName & getAllProperties: can now take an object as argument, not just error.
+
+## v0.6.8
+
+### Fix
+
+- Handle rejected echo modules
 
 ## v0.6.7
 

--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.16",
+    "version": "0.6.17",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.6.16",
+            "version": "0.6.17",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "^2.25.0",
@@ -19,7 +19,7 @@
                 "@babel/preset-env": "^7.18.2",
                 "@babel/preset-react": "^7.17.12",
                 "@babel/preset-typescript": "^7.17.12",
-                "@equinor/echo-base": "^0.6.8",
+                "@equinor/echo-base": "^0.6.9",
                 "@microsoft/microsoft-graph-types": "^2.20.0",
                 "@microsoft/microsoft-graph-types-beta": "^0.29.0-preview",
                 "@rollup/plugin-babel": "^5.3.1",
@@ -50,7 +50,7 @@
                 "typescript": "^4.7.3"
             },
             "peerDependencies": {
-                "@equinor/echo-base": "^0.6.8",
+                "@equinor/echo-base": "^0.6.9",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "react-router-dom": "^5.3.0"
@@ -1815,12 +1815,12 @@
             }
         },
         "node_modules/@equinor/echo-base": {
-            "version": "0.6.8",
-            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.6.8.tgz",
-            "integrity": "sha512-Jscj20GdOUVCBMBPv9HTldKJUO7MMDokIfXcZdhTSy/fK7dOtQP9sYYh+yAc+vQWlxFaYVlXhscYZN7E5vQNeQ==",
+            "version": "0.6.9",
+            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.6.9.tgz",
+            "integrity": "sha512-ID8y3ebIWVzCo+teL8JmdACYy6/gIy1wvA5pPW7x9DVWmWn4HjhhFVq9QpFwVN+CbV7GEJV1xGPmJ1iixqwZ+A==",
             "dev": true,
             "dependencies": {
-                "tslib": "^2.3.1"
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -7131,12 +7131,12 @@
             }
         },
         "@equinor/echo-base": {
-            "version": "0.6.8",
-            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.6.8.tgz",
-            "integrity": "sha512-Jscj20GdOUVCBMBPv9HTldKJUO7MMDokIfXcZdhTSy/fK7dOtQP9sYYh+yAc+vQWlxFaYVlXhscYZN7E5vQNeQ==",
+            "version": "0.6.9",
+            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.6.9.tgz",
+            "integrity": "sha512-ID8y3ebIWVzCo+teL8JmdACYy6/gIy1wvA5pPW7x9DVWmWn4HjhhFVq9QpFwVN+CbV7GEJV1xGPmJ1iixqwZ+A==",
             "dev": true,
             "requires": {
-                "tslib": "^2.3.1"
+                "tslib": "^2.4.0"
             }
         },
         "@eslint/eslintrc": {

--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -19,7 +19,7 @@
                 "@babel/preset-env": "^7.18.2",
                 "@babel/preset-react": "^7.17.12",
                 "@babel/preset-typescript": "^7.17.12",
-                "@equinor/echo-base": "^0.6.9",
+                "@equinor/echo-base": "^0.6.10",
                 "@microsoft/microsoft-graph-types": "^2.20.0",
                 "@microsoft/microsoft-graph-types-beta": "^0.29.0-preview",
                 "@rollup/plugin-babel": "^5.3.1",
@@ -50,7 +50,7 @@
                 "typescript": "^4.7.3"
             },
             "peerDependencies": {
-                "@equinor/echo-base": "^0.6.9",
+                "@equinor/echo-base": "^0.6.10",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
                 "react-router-dom": "^5.3.0"
@@ -1815,9 +1815,9 @@
             }
         },
         "node_modules/@equinor/echo-base": {
-            "version": "0.6.9",
-            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.6.9.tgz",
-            "integrity": "sha512-ID8y3ebIWVzCo+teL8JmdACYy6/gIy1wvA5pPW7x9DVWmWn4HjhhFVq9QpFwVN+CbV7GEJV1xGPmJ1iixqwZ+A==",
+            "version": "0.6.10",
+            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.6.10.tgz",
+            "integrity": "sha512-/DxtGRj64Wcwf1FTarJh4AH5uG2iBQw9NWeQPbzYVyqDJqJ709u1u9PeUR2+n+5tfcGAJZUTs0IXypF9Sq5qTA==",
             "dev": true,
             "dependencies": {
                 "tslib": "^2.4.0"
@@ -7131,9 +7131,9 @@
             }
         },
         "@equinor/echo-base": {
-            "version": "0.6.9",
-            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.6.9.tgz",
-            "integrity": "sha512-ID8y3ebIWVzCo+teL8JmdACYy6/gIy1wvA5pPW7x9DVWmWn4HjhhFVq9QpFwVN+CbV7GEJV1xGPmJ1iixqwZ+A==",
+            "version": "0.6.10",
+            "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.6.10.tgz",
+            "integrity": "sha512-/DxtGRj64Wcwf1FTarJh4AH5uG2iBQw9NWeQPbzYVyqDJqJ709u1u9PeUR2+n+5tfcGAJZUTs0IXypF9Sq5qTA==",
             "dev": true,
             "requires": {
                 "tslib": "^2.4.0"

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -30,7 +30,7 @@
         "directory": "packages/echo-core"
     },
     "peerDependencies": {
-        "@equinor/echo-base": "^0.6.9",
+        "@equinor/echo-base": "^0.6.10",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^5.3.0"
@@ -46,7 +46,7 @@
         "@babel/preset-env": "^7.18.2",
         "@babel/preset-react": "^7.17.12",
         "@babel/preset-typescript": "^7.17.12",
-        "@equinor/echo-base": "^0.6.9",
+        "@equinor/echo-base": "^0.6.10",
         "@microsoft/microsoft-graph-types": "^2.20.0",
         "@microsoft/microsoft-graph-types-beta": "^0.29.0-preview",
         "@rollup/plugin-babel": "^5.3.1",

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.16",
+    "version": "0.6.17",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
         "directory": "packages/echo-core"
     },
     "peerDependencies": {
-        "@equinor/echo-base": "^0.6.8",
+        "@equinor/echo-base": "^0.6.9",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^5.3.0"
@@ -46,7 +46,7 @@
         "@babel/preset-env": "^7.18.2",
         "@babel/preset-react": "^7.17.12",
         "@babel/preset-typescript": "^7.17.12",
-        "@equinor/echo-base": "^0.6.8",
+        "@equinor/echo-base": "^0.6.9",
         "@microsoft/microsoft-graph-types": "^2.20.0",
         "@microsoft/microsoft-graph-types-beta": "^0.29.0-preview",
         "@rollup/plugin-babel": "^5.3.1",

--- a/packages/echo-core/src/services/analytics/errorToExceptionTelemetry.ts
+++ b/packages/echo-core/src/services/analytics/errorToExceptionTelemetry.ts
@@ -23,6 +23,11 @@ export function errorToExceptionTelemetry(args: {
     const message = error.message ? error.message : '';
     const allProperties = getAllProperties(error);
     delete allProperties['hasBeenLogged']; //we don't want to log this
+    let innerError = allProperties['innerError'] as Record<string, unknown>;
+    while (innerError) {
+        delete innerError['hasBeenLogged']; //we don't want to log this
+        innerError = innerError['innerError'] as Record<string, unknown>;
+    }
 
     return {
         exception: error,


### PR DESCRIPTION
Had forgotten to export echoUtils.

Fixed: findPropertyByName now supports object, not just Error & Record.

Also updated changelog for the past versions