### PR TITLE
fix: #84416 Stuck api call because of outdated token.

### DIFF
--- a/packages/echo-core/CHANGELOG.md
+++ b/packages/echo-core/CHANGELOG.md
@@ -3,11 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## v0.6.23
+## v0.7.0
 
--   Breaking: EchoAuthProvider.userProperties is now correctly defined as optional. Instead use getUserProperties or getUserAccount to automatically start auth process if needed.
--   Breaking: EchoAuthProvider.userProperties.loginError removed. The auth process will now instead throw error if auth fails, forcing the app to deal with the error (log it to appInsight).
--   Changed: echoClient.getAccessToken will authenticate if necessary.
+### Breaking changes
+
+-   EchoAuthProvider.userProperties is now correctly defined as optional. Instead use getUserProperties or getUserAccount to automatically start auth process if needed.
+-   EchoAuthProvider.userProperties.loginError removed. The auth process will now instead throw error if auth fails, forcing the app to deal with the error (log it to appInsight).
+
+### Changed
+
+-   echoClient.getAccessToken will authenticate if necessary.
 
 ## v0.6.22
 

--- a/packages/echo-core/CHANGELOG.md
+++ b/packages/echo-core/CHANGELOG.md
@@ -10,9 +10,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 -   EchoAuthProvider.userProperties is now correctly defined as optional. Instead use getUserProperties or getUserAccount to automatically start auth process if needed.
 -   EchoAuthProvider.userProperties.loginError removed. The auth process will now instead throw error if auth fails, forcing the app to deal with the error (log it to appInsight).
 
-### Changed
+### Fix
 
 -   echoClient.getAccessToken will authenticate if necessary.
+-   getPlantsData will now load data from localStorage if it hasn't been set/loaded yet
 
 ## v0.6.22
 

--- a/packages/echo-core/CHANGELOG.md
+++ b/packages/echo-core/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## v0.6.23
+
+-   Breaking: EchoAuthProvider.userProperties is now correctly defined as optional. Instead use getUserProperties or getUserAccount to automatically start auth process if needed.
+-   Breaking: EchoAuthProvider.userProperties.loginError removed. The auth process will now instead throw error if auth fails, forcing the app to deal with the error (log it to appInsight).
+-   Changed: echoClient.getAccessToken will authenticate if necessary.
+
 ## v0.6.22
 
 -   Downgraded app insight package, as it breaks unit tests.

--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.7.0-rc1",
+    "version": "0.7.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.7.0-rc1",
+            "version": "0.7.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "^2.30.0",

--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.22",
+    "version": "0.6.23-rc1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.6.22",
+            "version": "0.6.23-rc1",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "^2.30.0",

--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.23-rc1",
+    "version": "0.7.0-rc1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.6.23-rc1",
+            "version": "0.7.0-rc1",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "^2.30.0",

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.7.0-rc1",
+    "version": "0.7.0",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.23-rc1",
+    "version": "0.7.0-rc1",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.6.22",
+    "version": "0.6.23-rc1",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/echo-core/src/__tests__/plants/globalPlantsDataActions.test.ts
+++ b/packages/echo-core/src/__tests__/plants/globalPlantsDataActions.test.ts
@@ -6,6 +6,7 @@ import { PlantsData } from '../../types/plants';
 
 beforeEach(() => {
     initialize();
+    setPlantsData({ plants: [] });
 });
 
 function initialize(): void {
@@ -33,7 +34,7 @@ const mockPlantsData: PlantsData = {
 
 describe('globalPlantsDataActions', () => {
     describe('getPlantsData', () => {
-        it('should return default plantsData', () => {
+        it('should return default/empty plantsData', () => {
             const result = getPlantsData();
             expect(result).toEqual(plantsData);
         });
@@ -42,12 +43,21 @@ describe('globalPlantsDataActions', () => {
             const result = getPlantsData();
             expect(result).toEqual(mockPlantsData);
         });
+
+        it('should clear plants', () => {
+            setPlantsData(mockPlantsData);
+            const result = getPlantsData();
+            expect(result).toEqual(mockPlantsData);
+
+            setPlantsData({ plants: [] });
+            const result2 = getPlantsData();
+            expect(result2).toEqual({ plants: [] });
+        });
     });
     describe('getPlants', () => {
-        it('should return default list of plants', () => {
-            const plants = plantsData.plants;
+        it('should return empty/default list of plants', () => {
             const result = getPlants();
-            expect(result).toEqual(plants);
+            expect(result).toStrictEqual(plantsData.plants);
         });
         it('should return new list of plants', () => {
             const plants = mockPlantsData.plants;

--- a/packages/echo-core/src/__tests__/services/graphUtils.test.ts
+++ b/packages/echo-core/src/__tests__/services/graphUtils.test.ts
@@ -17,14 +17,18 @@ jest.mock('../../configuration/environment', () => {
     };
 });
 
+const userProperties = {
+    account: {
+        username: 'test@test.no'
+    }
+};
+
 jest.mock('../../services/authentication/echoProvider', () => ({
     EchoAuthProvider: {
         aquireTokenSilentOrRedirectToAuthenticate: jest.fn(),
-        userProperties: {
-            account: {
-                username: 'test@test.no'
-            }
-        }
+        userProperties,
+        getUserProperties: () => userProperties,
+        getUserAccount: () => userProperties.account
     }
 }));
 
@@ -34,7 +38,7 @@ beforeEach(() => {
         account: { username: 'test@test.no' }
     } as unknown as AccountInfo;
 
-    EchoAuthProvider.userProperties.account = accountMock;
+    EchoAuthProvider.userProperties = { account: accountMock };
 });
 
 describe('graphGetProfile', () => {
@@ -82,13 +86,13 @@ describe('graphGetProfile', () => {
     });
 
     it('should return undefined because no account is present on auth provider', async () => {
-        EchoAuthProvider.userProperties.account = null;
+        EchoAuthProvider.userProperties = undefined;
 
         const aquireTokenSilentOrRedirectToAuthenticateSpy =
             EchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate as jest.Mock;
 
         const graphProfile = await graphGetProfile();
-        expect(aquireTokenSilentOrRedirectToAuthenticateSpy).not.toBeCalled();
+        expect(aquireTokenSilentOrRedirectToAuthenticateSpy).toBeCalled();
         expect(fetchMock).not.toBeCalled();
         expect(graphProfile).toBe(undefined);
     });
@@ -148,14 +152,14 @@ describe('graphGetProfilePicture', () => {
     });
 
     it('should return undefined because no account is present on auth provider', async () => {
-        EchoAuthProvider.userProperties.account = null;
+        EchoAuthProvider.userProperties = undefined;
 
         const aquireTokenSilentOrRedirectToAuthenticateSpy =
             EchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate as jest.Mock;
 
         const graphProfileUrl = await graphGetProfilePicture();
-        expect(aquireTokenSilentOrRedirectToAuthenticateSpy).not.toBeCalled();
-        expect(fetchMock).not.toBeCalled();
+        expect(aquireTokenSilentOrRedirectToAuthenticateSpy).toBeCalled();
+        expect(fetchMock).toBeCalled();
         expect(graphProfileUrl).toBe(undefined);
     });
 });

--- a/packages/echo-core/src/actions/plantsData.ts
+++ b/packages/echo-core/src/actions/plantsData.ts
@@ -5,7 +5,7 @@ import { GlobalState } from '../types/state';
 import { dispatch, readState } from './coreActions/globalActions';
 
 /**
- * Function for updating plantsData in global state. Existing data is kept/overwritten.
+ * Function for updating plantsData in global state.
  * @export
  * @param {Partial<PlantsData>} partialPlantsData
  */

--- a/packages/echo-core/src/actions/plantsData.ts
+++ b/packages/echo-core/src/actions/plantsData.ts
@@ -5,7 +5,7 @@ import { GlobalState } from '../types/state';
 import { dispatch, readState } from './coreActions/globalActions';
 
 /**
- * Function for updating plantsData in global state.
+ * Function for updating plantsData in global state. Existing data is kept/overwritten.
  * @export
  * @param {Partial<PlantsData>} partialPlantsData
  */
@@ -24,7 +24,20 @@ export function setPlantsData(partialPlantsData: Partial<PlantsData>): void {
  * @return {*}  {Readonly<PlantsData>}
  */
 export function getPlantsData(): Readonly<PlantsData> {
-    return readState(getCoreContext(), (state: GlobalState) => state.plantsData);
+    const plants = readState(getCoreContext(), (state: GlobalState) => state.plantsData);
+    if (plants.plants.length > 0) {
+        return plants;
+    }
+
+    const plantsFromStorage = persistPlantsData.getPlantsDataFromLocalStorage();
+    if (plantsFromStorage.plants.length > 0) {
+        dispatch(getCoreContext(), (state: GlobalState) => {
+            const newState = { ...state, plantsFromStorage };
+            return newState;
+        });
+    }
+
+    return plantsFromStorage;
 }
 
 /**

--- a/packages/echo-core/src/services/authentication/authProvider.ts
+++ b/packages/echo-core/src/services/authentication/authProvider.ts
@@ -149,7 +149,10 @@ export class AuthenticationProvider {
                     this.publicClient.acquireTokenRedirect(redirectRequest).catch(console.error).then();
                 } else {
                     console.error(er);
-                    throw er;
+                    throw new AuthenticationError({
+                        message: 'aquireTokenSilentOrRedirectToAuthenticate',
+                        innerError: er
+                    });
                 }
             });
         return authenticationResult ? authenticationResult : null;

--- a/packages/echo-core/src/services/authentication/authProvider.ts
+++ b/packages/echo-core/src/services/authentication/authProvider.ts
@@ -186,12 +186,3 @@ export class AuthenticationProvider {
         return adResult ? adResult.accessToken : undefined;
     };
 }
-
-function tokenExpiresInSeconds(userProperties: UserProperties) {
-    const expiration = userProperties?.account?.idTokenClaims?.exp ?? 0;
-    const now = Math.floor(Date.now() / 1000);
-    const expiresIn = expiration - now;
-    console.log('Token expires in', expiresIn);
-
-    return expiresIn;
-}

--- a/packages/echo-core/src/services/authentication/authProvider.ts
+++ b/packages/echo-core/src/services/authentication/authProvider.ts
@@ -26,8 +26,7 @@ import { defaultLoginRequest, loginSilentlyRequest, logoutRequest } from './auth
  */
 export class AuthenticationProvider {
     /**
-     * Deprecated userProperties property. Instead use getUserProperties() or getUserAccount()
-     * // @deprecated
+     * Instead use getUserProperties() or getUserAccount(), which will automatically authenticate and return the user properties.
      */
     userProperties?: UserProperties;
 

--- a/packages/echo-core/src/services/authentication/authProvider.ts
+++ b/packages/echo-core/src/services/authentication/authProvider.ts
@@ -35,10 +35,7 @@ export class AuthenticationProvider {
     loginRequest: RedirectRequest;
     isAuthenticated: boolean;
 
-    throwAnError: boolean;
-
     constructor(configuration: Configuration, loginRequest = defaultLoginRequest) {
-        this.throwAnError = false;
         this.publicClient = new PublicClientApplication(configuration);
         this.loginRequest = loginRequest;
         this.isAuthenticated = false;
@@ -101,8 +98,7 @@ export class AuthenticationProvider {
         await this.publicClient
             .acquireTokenSilent(loginSilentlyRequest(this.publicClient.getAllAccounts()[0]))
             .then((response) => {
-                if (!response.account || this.throwAnError) {
-                    this.throwAnError = false;
+                if (!response.account) {
                     throw new AuthenticationError({
                         message:
                             'account is null, failed to acquireTokenSilent loginSilentlyRequest getAllAccounts()[0]'

--- a/packages/echo-core/src/services/baseClient/authenticationError.ts
+++ b/packages/echo-core/src/services/baseClient/authenticationError.ts
@@ -1,0 +1,7 @@
+import { BaseError, ErrorArgs } from '@equinor/echo-base';
+
+export class AuthenticationError extends BaseError {
+    constructor(args: ErrorArgs) {
+        super({ ...args, name: 'AuthenticationError' });
+    }
+}

--- a/packages/echo-core/src/services/baseClient/baseClient.ts
+++ b/packages/echo-core/src/services/baseClient/baseClient.ts
@@ -1,13 +1,8 @@
 import { AccountInfo, SilentRequest } from '@azure/msal-browser';
-import { BaseError, ErrorArgs, toError } from '@equinor/echo-base';
+import { toError } from '@equinor/echo-base';
 import { AuthenticationProvider } from '../authentication/authProvider';
+import { AuthenticationError } from './authenticationError';
 import { fetchWithTokenLogic } from './fetchWithTokenLogic';
-
-export class AuthenticationError extends BaseError {
-    constructor(args: ErrorArgs) {
-        super({ ...args, name: 'AuthenticationError' });
-    }
-}
 
 /**
  * Base Client class providing methods for performing a fetch with authentication and acquiring AccessToken.

--- a/packages/echo-core/src/services/baseClient/baseClient.ts
+++ b/packages/echo-core/src/services/baseClient/baseClient.ts
@@ -32,7 +32,6 @@ export class BaseClient {
             );
             return authenticationResult ? authenticationResult.accessToken : '';
         } catch (exception) {
-            console.log(exception);
             throw new AuthenticationError({ message: 'failed to authenticate', innerError: toError(exception) });
         }
     }

--- a/packages/echo-core/src/services/baseClient/baseClient.ts
+++ b/packages/echo-core/src/services/baseClient/baseClient.ts
@@ -24,7 +24,7 @@ export class BaseClient {
      * @memberof BaseClient
      */
     async getAccessToken(): Promise<string> {
-        const userAccount = await this.authProvider.getUserAccount(); //should throw
+        const userAccount = await this.authProvider.getUserAccount(); // used to (if account null): throw new ArgumentError({ argumentName: 'authProvider.userProperties.account' });
         try {
             const authenticationResult = await this.authProvider.aquireTokenSilentOrRedirectToAuthenticate(
                 this.getSilentRequest(userAccount),
@@ -32,6 +32,7 @@ export class BaseClient {
             );
             return authenticationResult ? authenticationResult.accessToken : '';
         } catch (exception) {
+            console.log(exception);
             throw new AuthenticationError({ message: 'failed to authenticate', innerError: toError(exception) });
         }
     }
@@ -59,7 +60,7 @@ export class BaseClient {
         body?: BodyInit,
         signal?: AbortSignal
     ): Promise<Response> {
-        const accessToken = await this.getAccessToken(); //can throw
+        const accessToken = await this.getAccessToken(); // used to (if account null): throw new ArgumentError({ argumentName: 'authProvider.userProperties.account' });
         return await this.fetchWithToken(url, accessToken, headerOptions, method, body, signal);
     }
 

--- a/packages/echo-core/src/services/baseClient/baseClient.ts
+++ b/packages/echo-core/src/services/baseClient/baseClient.ts
@@ -1,5 +1,5 @@
 import { AccountInfo, SilentRequest } from '@azure/msal-browser';
-import { ArgumentError, BaseError, ErrorArgs, toError } from '@equinor/echo-base';
+import { BaseError, ErrorArgs, toError } from '@equinor/echo-base';
 import { AuthenticationProvider } from '../authentication/authProvider';
 import { fetchWithTokenLogic } from './fetchWithTokenLogic';
 
@@ -29,12 +29,10 @@ export class BaseClient {
      * @memberof BaseClient
      */
     async getAccessToken(): Promise<string> {
-        if (!this.authProvider.userProperties.account)
-            throw new ArgumentError({ argumentName: 'authProvider.userProperties.account' });
-
+        const userAccount = await this.authProvider.getUserAccount(); //should throw
         try {
             const authenticationResult = await this.authProvider.aquireTokenSilentOrRedirectToAuthenticate(
-                this.getSilentRequest(this.authProvider.userProperties.account),
+                this.getSilentRequest(userAccount),
                 this.authProvider.loginRequest
             );
             return authenticationResult ? authenticationResult.accessToken : '';
@@ -66,9 +64,7 @@ export class BaseClient {
         body?: BodyInit,
         signal?: AbortSignal
     ): Promise<Response> {
-        if (!this.authProvider.userProperties.account)
-            throw new ArgumentError({ argumentName: 'authProvider.userProperties.account' });
-        const accessToken = await this.getAccessToken();
+        const accessToken = await this.getAccessToken(); //can throw
         return await this.fetchWithToken(url, accessToken, headerOptions, method, body, signal);
     }
 

--- a/packages/echo-core/src/services/graph/graphUtils.ts
+++ b/packages/echo-core/src/services/graph/graphUtils.ts
@@ -40,10 +40,10 @@ export const graphGetProfilePicture = async (): Promise<string | undefined> => {
 };
 
 async function authenticate(): Promise<AuthenticationResult | null> {
-    if (!EchoAuthProvider.userProperties.account) return null;
+    const userAccount = await EchoAuthProvider.getUserAccount();
 
     return await EchoAuthProvider.aquireTokenSilentOrRedirectToAuthenticate(
-        graphApiRequest(EchoAuthProvider.userProperties.account),
+        graphApiRequest(userAccount),
         EchoAuthProvider.loginRequest
     );
 }

--- a/packages/echo-core/src/types/userProperties.ts
+++ b/packages/echo-core/src/types/userProperties.ts
@@ -1,6 +1,5 @@
 import { AccountInfo } from '@azure/msal-browser';
 
 export interface UserProperties {
-    account: AccountInfo | null;
-    loginError: boolean;
+    account: AccountInfo;
 }


### PR DESCRIPTION
Temporary published as 0.7.0-rc1, and used in dev for testing. Also tested with yalc.

The stuck api calls happens after 1-2 hours of idle iPad. And sometimes on PC. We now auto refresh it in echoClient.getAccessToken 

## v0.7.0

### Breaking changes

-   EchoAuthProvider.userProperties is now correctly defined as optional. Instead use getUserProperties or getUserAccount to automatically start auth process if needed.
-   EchoAuthProvider.userProperties.loginError removed. The auth process will now instead throw error if auth fails, forcing the app to deal with the error (log it to appInsight).

### Fix

-   echoClient.getAccessToken will authenticate if necessary.
-   getPlantsData will now load data from localStorage if it hasn't been set/loaded yet