### PR TITLE
chore: Version bump to 0.7.4

### DIFF
--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.7.3",
+            "version": "0.7.4",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "^2.32.2",

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
### What's happening here:
 - Bumped version to release changes in envVars done here (https://github.com/equinor/EchoCore/commit/30f7dd2e980e080e05d3c1b543d8983b12a26335)

