### PR TITLE
feat: #99088 React 18 upgrade - Change echo core state management tool

### DIFF
--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "^2.32.2",
-                "@dbeining/react-atom": "^4.1.21",
                 "@microsoft/applicationinsights-web": "^2.8.9",
                 "sha1": "^1.1.1",
                 "zustand": "^4.3.2"
@@ -1830,18 +1829,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@dbeining/react-atom": {
-            "version": "4.1.21",
-            "resolved": "https://registry.npmjs.org/@dbeining/react-atom/-/react-atom-4.1.21.tgz",
-            "integrity": "sha512-lHAyDaIlLpcx5hl6YOv6FFxODOE+Qa2nsvA/oAlk4dv7AWR6hbb3nBU6naaOwFVY3l7urBPJezmNxI/Pixo1Pg==",
-            "dependencies": {
-                "@libre/atom": "^1.3.2"
-            },
-            "peerDependencies": {
-                "react": ">=16.7.0-alpha.0 || >=16.8.0-alpha.0 || >= 16.8.0 < 17",
-                "react-dom": ">=16.7.0-alpha.0 || >=16.8.0-alpha.0 || >= 16.8.0 < 17"
-            }
-        },
         "node_modules/@equinor/echo-base": {
             "version": "0.6.22",
             "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.6.22.tgz",
@@ -2080,11 +2067,6 @@
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
-        },
-        "node_modules/@libre/atom": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@libre/atom/-/atom-1.3.3.tgz",
-            "integrity": "sha512-u6VDBBeSYuxBIdyGV1FybaeYndP/E8npGKzbYJgxUKQ0L9MsBMWuEP0O/45KcdNhnEaxm+GozSvkGgMJtoWBqg=="
         },
         "node_modules/@microsoft/applicationinsights-analytics-js": {
             "version": "2.8.9",
@@ -5576,6 +5558,7 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
             "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -5978,6 +5961,7 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
             "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -7747,14 +7731,6 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
-        "@dbeining/react-atom": {
-            "version": "4.1.21",
-            "resolved": "https://registry.npmjs.org/@dbeining/react-atom/-/react-atom-4.1.21.tgz",
-            "integrity": "sha512-lHAyDaIlLpcx5hl6YOv6FFxODOE+Qa2nsvA/oAlk4dv7AWR6hbb3nBU6naaOwFVY3l7urBPJezmNxI/Pixo1Pg==",
-            "requires": {
-                "@libre/atom": "^1.3.2"
-            }
-        },
         "@equinor/echo-base": {
             "version": "0.6.22",
             "resolved": "https://registry.npmjs.org/@equinor/echo-base/-/echo-base-0.6.22.tgz",
@@ -7936,11 +7912,6 @@
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
-        },
-        "@libre/atom": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@libre/atom/-/atom-1.3.3.tgz",
-            "integrity": "sha512-u6VDBBeSYuxBIdyGV1FybaeYndP/E8npGKzbYJgxUKQ0L9MsBMWuEP0O/45KcdNhnEaxm+GozSvkGgMJtoWBqg=="
         },
         "@microsoft/applicationinsights-analytics-js": {
             "version": "2.8.9",
@@ -10496,6 +10467,7 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
             "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
@@ -10801,6 +10773,7 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
             "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"

--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -12,7 +12,8 @@
                 "@azure/msal-browser": "^2.32.2",
                 "@dbeining/react-atom": "^4.1.21",
                 "@microsoft/applicationinsights-web": "^2.8.9",
-                "sha1": "^1.1.1"
+                "sha1": "^1.1.1",
+                "zustand": "^4.3.2"
             },
             "devDependencies": {
                 "@babel/core": "^7.20.12",
@@ -4249,6 +4250,17 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immer": {
+            "version": "9.0.19",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.19.tgz",
+            "integrity": "sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ==",
+            "optional": true,
+            "peer": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -6400,6 +6412,14 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/use-sync-external-store": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/value-equal": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
@@ -6480,6 +6500,29 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zustand": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.2.tgz",
+            "integrity": "sha512-rd4haDmlwMTVWVqwvgy00ny8rtti/klRoZjFbL/MAcDnmD5qSw/RZc+Vddstdv90M5Lv6RPgWvm1Hivyn0QgJw==",
+            "dependencies": {
+                "use-sync-external-store": "1.2.0"
+            },
+            "engines": {
+                "node": ">=12.7.0"
+            },
+            "peerDependencies": {
+                "immer": ">=9.0",
+                "react": ">=16.8"
+            },
+            "peerDependenciesMeta": {
+                "immer": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                }
             }
         }
     },
@@ -9482,6 +9525,13 @@
             "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
             "dev": true
         },
+        "immer": {
+            "version": "9.0.19",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.19.tgz",
+            "integrity": "sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ==",
+            "optional": true,
+            "peer": true
+        },
         "import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -11072,6 +11122,12 @@
                 "punycode": "^2.1.0"
             }
         },
+        "use-sync-external-store": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+            "requires": {}
+        },
         "value-equal": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
@@ -11135,6 +11191,14 @@
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true
+        },
+        "zustand": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.2.tgz",
+            "integrity": "sha512-rd4haDmlwMTVWVqwvgy00ny8rtti/klRoZjFbL/MAcDnmD5qSw/RZc+Vddstdv90M5Lv6RPgWvm1Hivyn0QgJw==",
+            "requires": {
+                "use-sync-external-store": "1.2.0"
+            }
         }
     }
 }

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -39,7 +39,8 @@
         "@azure/msal-browser": "^2.32.2",
         "@dbeining/react-atom": "^4.1.21",
         "@microsoft/applicationinsights-web": "^2.8.9",
-        "sha1": "^1.1.1"
+        "sha1": "^1.1.1",
+        "zustand": "^4.3.2"
     },
     "devDependencies": {
         "@babel/core": "^7.20.12",

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -37,7 +37,6 @@
     },
     "dependencies": {
         "@azure/msal-browser": "^2.32.2",
-        "@dbeining/react-atom": "^4.1.21",
         "@microsoft/applicationinsights-web": "^2.8.9",
         "sha1": "^1.1.1",
         "zustand": "^4.3.2"

--- a/packages/echo-core/src/__tests__/state/globalState.test.ts
+++ b/packages/echo-core/src/__tests__/state/globalState.test.ts
@@ -1,33 +1,22 @@
-import { deref } from '@dbeining/react-atom';
-import { defaultGlobalState } from '../../state/defaultStates';
-import { createGlobalApplicationContext, createGlobalState, getCoreContext } from '../../state/globalState';
-import { GlobalsStateActions } from '../../types/actions';
-import { GlobalStateContext } from '../../types/state';
+import { getCoreContext, getCoreState, globalStore } from '../../state/globalState';
 
-describe('createGlobalState', () => {
-    it('should return empty Atom global state ', () => {
-        const result = deref(createGlobalState(defaultGlobalState));
-        expect(result).toStrictEqual(defaultGlobalState);
-    });
-});
-
-describe('createGlobalApplicationContext', () => {
+describe('getCoreContext()', () => {
     it('should return global context ', () => {
-        const globalState = createGlobalState(defaultGlobalState);
-        const expected: GlobalStateContext = {
-            state: globalState,
-            actions: {} as GlobalsStateActions
-        };
-        const result = createGlobalApplicationContext(globalState);
-        expect(result).toStrictEqual(expected);
-    });
-});
-
-describe('getCoreContext', () => {
-    it('should return global context ', () => {
-        const globalState = createGlobalState(defaultGlobalState);
-        const expected = createGlobalApplicationContext(globalState);
+        // when
         const result = getCoreContext();
-        expect(result).toStrictEqual(expected);
+
+        // then
+        expect(result).toStrictEqual({
+            state: globalStore,
+            actions: {}
+        });
     });
+});
+
+describe('getCoreState()', () => {
+    // when
+    const result = getCoreState();
+
+    // then
+    expect(result).toStrictEqual(globalStore);
 });

--- a/packages/echo-core/src/__tests__/state/useGlobalState.test.ts
+++ b/packages/echo-core/src/__tests__/state/useGlobalState.test.ts
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { globalStore } from '../../state/globalState';
+import { useGlobalState } from '../../state/useGlobalState';
+import { GlobalState } from '../../types';
+
+describe('useGlobalState()', () => {
+    it('should handle a passed function selector', () => {
+        // given
+
+        // when
+        const { result } = renderHook(() => useGlobalState((state: GlobalState) => state.settings));
+
+        // then
+        expect(result.current).toEqual({
+            selectedProcosysProject: '',
+            showTextHighlighting: true,
+            plantSettings: {
+                instCode: '',
+                hasTr2000: false,
+                sapPlantId: '',
+                proCoSysPlantId: '',
+                plantName: ''
+            }
+        });
+    });
+
+    it('should handle when no selector is passed: and return with the whole state', () => {
+        // given
+
+        // when
+        const { result } = renderHook(() => useGlobalState());
+
+        // then
+        expect(result.current).toEqual(globalStore.getState());
+    });
+});

--- a/packages/echo-core/src/actions/coreActions/globalActions.ts
+++ b/packages/echo-core/src/actions/coreActions/globalActions.ts
@@ -1,4 +1,3 @@
-import { deref, swap } from '@dbeining/react-atom';
 import { GlobalState, GlobalStateContext } from '../../types';
 
 /**
@@ -7,7 +6,7 @@ import { GlobalState, GlobalStateContext } from '../../types';
  * @param update callback function for updating the state.
  */
 export function dispatch(ctx: GlobalStateContext, update: (state: GlobalState) => GlobalState): void {
-    swap(ctx.state, update);
+    ctx.state.setState((state) => update(state));
 }
 
 /**
@@ -16,6 +15,6 @@ export function dispatch(ctx: GlobalStateContext, update: (state: GlobalState) =
  * @param read callback function for reading state parameters.
  */
 export function readState<S>(ctx: GlobalStateContext, read: (state: GlobalState) => S): S {
-    const state = deref<GlobalState>(ctx.state);
+    const state = ctx.state.getState();
     return read(state);
 }

--- a/packages/echo-core/src/hooks/useApp.ts
+++ b/packages/echo-core/src/hooks/useApp.ts
@@ -1,5 +1,5 @@
 import { useGlobalState } from '../state/useGlobalState';
-import { ActivePanel, ActiveState, EchoAppState, GlobalState } from '../types';
+import { ActivePanel, ActiveState, EchoAppState } from '../types';
 
 /**
  *
@@ -8,7 +8,7 @@ import { ActivePanel, ActiveState, EchoAppState, GlobalState } from '../types';
  * @return {*}  {EchoAppState}
  */
 export function useAppState(): EchoAppState {
-    return useGlobalState((state: GlobalState) => state.app);
+    return useGlobalState((state) => state.app);
 }
 
 /**

--- a/packages/echo-core/src/hooks/useLegendOptions.ts
+++ b/packages/echo-core/src/hooks/useLegendOptions.ts
@@ -1,10 +1,7 @@
-import { useAtom } from '@dbeining/react-atom';
-import { CoreContext } from '../state/globalState';
+import { useGlobalState } from '../state/useGlobalState';
 import { LegendOptions } from '../types/legend';
 
 export function useLegendOptions(): LegendOptions {
-    const { legendOptions } = useAtom(CoreContext.state);
+    const legendOptions = useGlobalState((state) => state.legendOptions);
     return { ...legendOptions };
 }
-
-export default useLegendOptions;

--- a/packages/echo-core/src/hooks/usePanelUI.ts
+++ b/packages/echo-core/src/hooks/usePanelUI.ts
@@ -1,5 +1,4 @@
-import { useAtom } from '@dbeining/react-atom';
-import { CoreContext } from '../state/globalState';
+import { useGlobalState } from '../state/useGlobalState';
 import { PanelUI } from '../types/ui';
 
 /**
@@ -7,6 +6,5 @@ import { PanelUI } from '../types/ui';
  * @return {PanelUI}  Reads the ui state and returns a partial ui-object of type PanelUI
  */
 export function usePanelUI(): PanelUI {
-    const { ui } = useAtom(CoreContext.state);
-    return ui;
+    return useGlobalState((state) => state.ui);
 }

--- a/packages/echo-core/src/hooks/useUserPhoto.ts
+++ b/packages/echo-core/src/hooks/useUserPhoto.ts
@@ -1,11 +1,8 @@
-import { useAtom } from '@dbeining/react-atom';
-import { CoreContext } from '../state/globalState';
+import { useGlobalState } from '../state/useGlobalState';
 
 /**
  * Echo Core function for getting the graph user photo url from the echo core state.
  */
 export function useUserPhoto(): string | undefined {
-    const { userPhotoUrl } = useAtom(CoreContext.state);
-    return userPhotoUrl;
+    return useGlobalState((state) => state.userPhotoUrl);
 }
-export default useUserPhoto;

--- a/packages/echo-core/src/hooks/useUserProfile.ts
+++ b/packages/echo-core/src/hooks/useUserProfile.ts
@@ -1,13 +1,9 @@
-import { useAtom } from '@dbeining/react-atom';
 import { User } from '@microsoft/microsoft-graph-types';
-import { CoreContext } from '../state/globalState';
+import { useGlobalState } from '../state/useGlobalState';
 
 /**
  * Echo Core function for getting the graph user profile from echo core state.
  */
 export function useUserProfile(): User | undefined {
-    const { userProfile } = useAtom(CoreContext.state);
-    return userProfile;
+    return useGlobalState((state) => state.userProfile);
 }
-
-export default useUserProfile;

--- a/packages/echo-core/src/hooks/useUserProfileBeta.ts
+++ b/packages/echo-core/src/hooks/useUserProfileBeta.ts
@@ -1,13 +1,11 @@
-import { useAtom } from '@dbeining/react-atom';
 import { UserProfileBeta } from '../services/graph/graphTypes';
-import { CoreContext } from '../state/globalState';
+import { useGlobalState } from '../state/useGlobalState';
 
 /**
  * Echo Core function for getting the graph user profile beta from echo core state.
  */
 export function useUserProfileBeta(): UserProfileBeta | undefined {
-    const { userProfileBeta } = useAtom(CoreContext.state);
-    return userProfileBeta;
+    return useGlobalState((state) => state.userProfileBeta);
 }
 
 export default useUserProfileBeta;

--- a/packages/echo-core/src/state/globalState.ts
+++ b/packages/echo-core/src/state/globalState.ts
@@ -1,6 +1,8 @@
-import { Atom } from '@dbeining/react-atom';
-import { GlobalState, GlobalStateContext } from '../types';
+import { useStore } from 'zustand';
+import { createStore, StoreApi } from 'zustand/vanilla';
+import { GlobalStateContext } from '../types';
 import { GlobalsStateActions } from '../types/actions';
+import { GlobalState } from './../types/state';
 import { defaultGlobalState } from './defaultStates';
 
 /**
@@ -10,9 +12,11 @@ import { defaultGlobalState } from './defaultStates';
  *
  * `Echo Core only`
  */
-export function createGlobalState(defaultState: GlobalState): Atom<GlobalState> {
-    return Atom.of(defaultState);
-}
+export const globalStore = createStore(() => ({
+    ...defaultGlobalState
+}));
+
+export const useGlobalStore = <T>(selector: (state: GlobalState) => T) => useStore(globalStore, selector);
 
 /**
  * Echo Core function for creating the GlobalApplicationContext.
@@ -21,13 +25,12 @@ export function createGlobalState(defaultState: GlobalState): Atom<GlobalState> 
  *
  * `Echo Core only.`
  */
-export function createGlobalApplicationContext(state: Atom<GlobalState>): GlobalStateContext {
-    const ctx: GlobalStateContext = {
-        state,
+export function createGlobalApplicationContext(store: StoreApi<GlobalState>): GlobalStateContext {
+    return {
+        state: store,
         actions: {} as GlobalsStateActions
         // Todo update with httpApi, authentication and more...
     };
-    return ctx;
 }
 
 /**
@@ -36,7 +39,7 @@ export function createGlobalApplicationContext(state: Atom<GlobalState>): Global
  *
  * `Echo Core only.`
  */
-export const CoreContext = createGlobalApplicationContext(createGlobalState(defaultGlobalState));
+export const CoreContext = createGlobalApplicationContext(globalStore);
 
 /**
  * Exposing the Echo GlobalStateContext
@@ -52,6 +55,6 @@ export function getCoreContext(): GlobalStateContext {
  *
  * `Echo Framework and Echo Core`
  */
-export function getCoreState(): Atom<GlobalState> {
+export function getCoreState(): StoreApi<GlobalState> {
     return CoreContext.state;
 }

--- a/packages/echo-core/src/state/globalState.ts
+++ b/packages/echo-core/src/state/globalState.ts
@@ -25,7 +25,7 @@ export const useGlobalStore = <T>(selector: (state: GlobalState) => T) => useSto
  *
  * `Echo Core only.`
  */
-export function createGlobalApplicationContext(store: StoreApi<GlobalState>): GlobalStateContext {
+function createGlobalApplicationContext(store: StoreApi<GlobalState>): GlobalStateContext {
     return {
         state: store,
         actions: {} as GlobalsStateActions
@@ -39,7 +39,7 @@ export function createGlobalApplicationContext(store: StoreApi<GlobalState>): Gl
  *
  * `Echo Core only.`
  */
-export const CoreContext = createGlobalApplicationContext(globalStore);
+const CoreContext = createGlobalApplicationContext(globalStore);
 
 /**
  * Exposing the Echo GlobalStateContext

--- a/packages/echo-core/src/state/globalState.ts
+++ b/packages/echo-core/src/state/globalState.ts
@@ -39,7 +39,7 @@ function createGlobalApplicationContext(store: StoreApi<GlobalState>): GlobalSta
  *
  * `Echo Core only.`
  */
-const CoreContext = createGlobalApplicationContext(globalStore);
+export const CoreContext = createGlobalApplicationContext(globalStore);
 
 /**
  * Exposing the Echo GlobalStateContext

--- a/packages/echo-core/src/state/useAppModuleState.ts
+++ b/packages/echo-core/src/state/useAppModuleState.ts
@@ -1,7 +1,6 @@
-import { useAtom } from '@dbeining/react-atom';
 import useInitial from '../hooks/useInitial';
 import { registerModuleState } from '../modules/moduleContext';
-import { getCoreState } from './globalState';
+import { useGlobalState } from './useGlobalState';
 
 /**
  * Hook for handling the application module state object.
@@ -9,11 +8,9 @@ import { getCoreState } from './globalState';
  * this parameter is default undefined for preventing initialization on every render.
  */
 export function useAppModuleState<T>(initialState: T | undefined = undefined): T {
-    const state = useAtom(getCoreState());
-
     useInitial(() => {
         initialState && registerModuleState(initialState);
     });
 
-    return state.moduleState as T;
+    return useGlobalState<T>((state) => state.moduleState as T);
 }

--- a/packages/echo-core/src/state/useGlobalState.ts
+++ b/packages/echo-core/src/state/useGlobalState.ts
@@ -1,6 +1,5 @@
-import { useAtom } from '@dbeining/react-atom';
 import { GlobalState } from '../types/state';
-import { getCoreState } from './globalState';
+import { useGlobalStore } from './globalState';
 
 /**
  * Hook that yields the full global state.
@@ -16,6 +15,6 @@ export function useGlobalState(): GlobalState;
 export function useGlobalState<R>(select: (state: GlobalState) => R): R;
 
 export function useGlobalState<R>(select?: (state: GlobalState) => R): GlobalState | R {
-    const state = useAtom(getCoreState());
-    return typeof select === 'function' ? select(state) : state;
+    const selector = typeof select === 'function' ? select : (state: GlobalState) => state as unknown as R;
+    return useGlobalStore(selector);
 }

--- a/packages/echo-core/src/types/state.ts
+++ b/packages/echo-core/src/types/state.ts
@@ -1,6 +1,6 @@
-import { Atom } from '@dbeining/react-atom';
 import { User } from '@microsoft/microsoft-graph-types';
 import React from 'react';
+import { StoreApi } from 'zustand/vanilla';
 import { UserProfileBeta } from '../services/graph/graphTypes';
 import { GlobalsStateActions } from './actions';
 import { Dict, EmptyObject } from './common';
@@ -14,7 +14,7 @@ import { Settings } from './settings';
 import { PanelUI, UI } from './ui';
 
 /**
- * The global state, the hart of Echo. The state contains user related data,
+ * The global state, the heart of Echo. The state contains user related data,
  * like user info and application settings. This state is not meant to have any search data
  * or large data sets. The active module is able to use the moduleState or the context provider.
  *
@@ -38,7 +38,7 @@ export interface GlobalState {
     moduleContext: ModuleContext<unknown>;
 }
 export interface GlobalStateContext {
-    state: Atom<GlobalState>;
+    state: StoreApi<GlobalState>;
     actions: GlobalsStateActions;
 }
 


### PR DESCRIPTION
⚠️ This PR will not be merged directly to main branch ⚠️ 
After the review it will be merged into the react 18 upgrade branch.

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

-   [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
-   [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] I have updated the documentation accordingly
-   [x] I have added tests to cover my changes

### Description

We're planning to upgrade Echo to use React 18.
Issue:
The `@dbeining/react-atom` state management tool used by EchoCore is no longer maintained, and it does not support React 18.

Using a different, more up to date state manager tool: `zustand`.

Luckly the different state handler functions are atomic, well defined functions.
As a result only the underlying react-atom APIs had to be changed => no breaking changes!

### Remarks

React 18 upgrade branch for echoCore:
https://github.com/equinor/EchoCore/tree/patch/upgrade-to-react-18

Related PRs
* EchopediaWeb: https://github.com/equinor/EchopediaWeb/pull/1348
* EchoComponents: https://github.com/equinor/EchoComponents/pull/83
* EchoFramework: https://github.com/equinor/EchoFramework/pull/286
* EchoUtils: https://github.com/equinor/EchoUtils/pull/72

