### PR TITLE
feat: #120905 - Event to show turnaround menu in bucket panel

### DIFF
--- a/packages/echo-core/package-lock.json
+++ b/packages/echo-core/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@equinor/echo-core",
-            "version": "0.8.2",
+            "version": "0.8.3",
             "license": "MIT",
             "dependencies": {
                 "@azure/msal-browser": "^2.37.1",

--- a/packages/echo-core/package.json
+++ b/packages/echo-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@equinor/echo-core",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "description": "Echo Core - Core functionality for the echo.equinor.com",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/echo-core/src/types/echoEvents.ts
+++ b/packages/echo-core/src/types/echoEvents.ts
@@ -4,5 +4,6 @@ export enum EchoEvents {
     ProcosysProjectChanged = 'procosysProjectChanged',
     Toaster = 'toaster',
     SearchItemDetailsClosed = 'SearchItemDetailsClosed',
-    FullScreenModeEnabled = 'fullScreenModeEnabled'
+    FullScreenModeEnabled = 'fullScreenModeEnabled',
+    TurnaroundDataSelectionButtonClicked = 'turnaroundDataSelectionButtonClicked'
 }


### PR DESCRIPTION
### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

-   [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)

### Description

When clicking Data Selection button in turnaround Grid, the left side bucket panel should display with the turnaround menu open. 
This PR adds an event which is emitted when clicking the Data Selection button.

### Related PR
EchopediaWeb: https://github.com/equinor/EchopediaWeb/pull/1863

### Related Task
https://dev.azure.com/EquinorASA/Echo/_workitems/edit/121829